### PR TITLE
fix: 고웨이브 HP Infinity 버그 + 밸런스 조정 + 유닛 테스트 (#3, #6, #8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                 </div>
                 <div class="control-row wave-control">
                     <label for="wave-input" class="control-label">웨이브 이동</label>
-                    <input type="number" id="wave-input" min="1" value="1">
+                    <input type="number" id="wave-input" min="1" max="9999" value="1">
                     <button type="button" id="wave-apply">이동</button>
                 </div>
                 <div class="control-row sound-control">

--- a/main.js
+++ b/main.js
@@ -9,13 +9,14 @@ const TOWER_DRAW_BASE = 14;
 const TOWER_PICK_RADIUS = 18;
 const ENEMY_RADIUS = 14;
 const ENEMY_BASE_HP = 78;
-const ENEMY_HP_GROWTH_RATE = 1.25;
+const ENEMY_HP_GROWTH_RATE = 1.18;
 const ENEMY_SPEED = 49;
 const ENEMY_BASE_REWARD = 14;
 const TOWER_UPGRADE_BASE_COST = 40;
-const TOWER_DAMAGE_GROWTH = 2.5;
-const TOWER_UPGRADE_COST_MULTIPLIER = 2;
+const TOWER_DAMAGE_GROWTH = 1.5;
+const TOWER_UPGRADE_COST_MULTIPLIER = 1.6;
 const TOWER_MAX_LEVEL = 15;
+const WAVE_MAX = 9999;
 const DEFAULT_TOWER_TYPE = "basic";
 
 const ENEMY_STYLES = [
@@ -879,9 +880,9 @@ function getWaveEnemyCount(waveNumber) {
 
 function getWaveEnemyStats(waveNumber) {
     const growth = Math.pow(ENEMY_HP_GROWTH_RATE, Math.max(0, waveNumber - 1));
-    const hp = Math.round(ENEMY_BASE_HP * growth);
+    const hp = Math.round(Math.min(ENEMY_BASE_HP * growth, Number.MAX_SAFE_INTEGER));
     const speed = ENEMY_SPEED;
-    const reward = ENEMY_BASE_REWARD;
+    const reward = Math.round(ENEMY_BASE_REWARD + waveNumber * 1.5);
     const count = getWaveEnemyCount(waveNumber);
     return { hp, speed, reward, count };
 }
@@ -963,7 +964,7 @@ function setWave(targetWave) {
         }
         return;
     }
-    const desiredWave = Math.max(1, Math.floor(targetWave));
+    const desiredWave = Math.max(1, Math.min(WAVE_MAX, Math.floor(targetWave)));
     clearCurrentWave();
     selectedTowerType = DEFAULT_TOWER_TYPE;
     setSelectedTowerButton(selectedTowerType);
@@ -2774,6 +2775,10 @@ if (WAVE_INPUT) {
 }
 
 requestAnimationFrame(loop);
+
+if (typeof module !== 'undefined') {
+    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, enemies };
+}
 
 
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
                         "doc":  "docs"
                     },
     "scripts":  {
-                    "test":  "node tests/smoke.test.js"
+                    "test":  "node tests/smoke.test.js && node tests/unit.test.js"
                 },
     "keywords":  [
 

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -1,0 +1,182 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+function noop() {}
+
+class FakeGainNode {
+    constructor() {
+        this.gain = {
+            value: 0,
+            setValueAtTime: noop,
+            setTargetAtTime: noop,
+            exponentialRampToValueAtTime: noop,
+            cancelScheduledValues: noop
+        };
+    }
+    connect() {}
+}
+
+class FakeOscillator {
+    constructor() {
+        this.frequency = { setValueAtTime: noop };
+        this.type = 'sine';
+    }
+    connect() {}
+    start() {}
+    stop() {}
+}
+
+class FakeBufferSource {
+    connect() {}
+    start() {}
+    stop() {}
+    set buffer(_) {}
+}
+
+class FakeAudioContext {
+    constructor() {
+        this.destination = {};
+        this.currentTime = 0;
+        this.sampleRate = 44100;
+    }
+    createGain() { return new FakeGainNode(); }
+    createOscillator() { return new FakeOscillator(); }
+    createBuffer(channels, length) {
+        return { getChannelData: () => new Float32Array(length * channels) };
+    }
+    createBufferSource() { return new FakeBufferSource(); }
+}
+
+function setupDom() {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf-8');
+    const dom = new JSDOM(html, { pretendToBeVisual: true });
+    const { window } = dom;
+    const { document } = window;
+
+    const fakePerformance = { now: () => 0 };
+    global.window = window;
+    global.document = document;
+    global.navigator = window.navigator;
+    global.performance = fakePerformance;
+    window.performance = fakePerformance;
+
+    global.requestAnimationFrame = noop;
+    global.cancelAnimationFrame = noop;
+    window.requestAnimationFrame = noop;
+    window.cancelAnimationFrame = noop;
+
+    window.AudioContext = FakeAudioContext;
+    window.webkitAudioContext = FakeAudioContext;
+    global.AudioContext = FakeAudioContext;
+
+    window.HTMLCanvasElement.prototype.getContext = () => ({
+        fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+        beginPath: noop, moveTo: noop, lineTo: noop, stroke: noop,
+        arc: noop, fillRect: noop, clearRect: noop, fill: noop,
+        save: noop, restore: noop, font: '', textAlign: '', textBaseline: '',
+        fillText: noop,
+        createRadialGradient: () => ({ addColorStop: noop }),
+        createLinearGradient: () => ({ addColorStop: noop })
+    });
+
+    delete require.cache[require.resolve('../main.js')];
+    const game = require('../main.js');
+
+    return { window, document, game };
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error(`FAIL: ${message}`);
+}
+
+function assertEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(`FAIL: ${message}\n  expected: ${expected}\n  got:      ${actual}`);
+    }
+}
+
+function run() {
+    const { game } = setupDom();
+    const {
+        calculateTowerDamage,
+        calculateUpgradeCost,
+        getWaveEnemyCount,
+        getWaveEnemyStats,
+        applyExplosion,
+        enemies
+    } = game;
+
+    // --- calculateTowerDamage ---
+    const basicDef = { baseDamage: 20 };
+    assertEqual(
+        calculateTowerDamage(basicDef, 1),
+        20,
+        'calculateTowerDamage: 레벨 1 피해는 baseDamage와 동일'
+    );
+    assertEqual(
+        calculateTowerDamage(basicDef, 2),
+        parseFloat((20 * 1.5).toFixed(4)),
+        'calculateTowerDamage: 레벨 2 피해는 baseDamage * TOWER_DAMAGE_GROWTH(1.5)'
+    );
+
+    // --- calculateUpgradeCost ---
+    const def40 = { baseUpgradeCost: 40 };
+    assertEqual(
+        calculateUpgradeCost(def40, 1),
+        40,
+        'calculateUpgradeCost: 레벨 1 비용 = baseUpgradeCost'
+    );
+    assertEqual(
+        calculateUpgradeCost(def40, 2),
+        Math.round(40 * 1.6),
+        'calculateUpgradeCost: 레벨 2 비용 = base * TOWER_UPGRADE_COST_MULTIPLIER(1.6)'
+    );
+
+    // --- getWaveEnemyCount ---
+    assertEqual(getWaveEnemyCount(1), 9, 'getWaveEnemyCount: 웨이브 1 = 8 + floor(1.5) = 9');
+    assertEqual(getWaveEnemyCount(10), 23, 'getWaveEnemyCount: 웨이브 10 = 8 + floor(15) = 23');
+
+    // --- getWaveEnemyStats HP 스케일링 ---
+    const stats1 = getWaveEnemyStats(1);
+    assertEqual(stats1.hp, 78, 'getWaveEnemyStats: 웨이브 1 체력 = ENEMY_BASE_HP(78)');
+
+    const stats2 = getWaveEnemyStats(2);
+    assertEqual(stats2.hp, Math.round(78 * 1.18), 'getWaveEnemyStats: 웨이브 2 체력 = 78 * 1.18');
+
+    // --- getWaveEnemyStats 고웨이브 Infinity 방어 ---
+    const statsHigh = getWaveEnemyStats(9999);
+    assert(Number.isFinite(statsHigh.hp), 'getWaveEnemyStats: 웨이브 9999 체력은 유한수');
+    assert(statsHigh.hp <= Number.MAX_SAFE_INTEGER, 'getWaveEnemyStats: 웨이브 9999 체력은 MAX_SAFE_INTEGER 이하');
+
+    // --- getWaveEnemyStats 보상 스케일링 ---
+    const reward1 = getWaveEnemyStats(1).reward;
+    assertEqual(reward1, Math.round(14 + 1 * 1.5), 'getWaveEnemyStats: 웨이브 1 보상 = 14 + 1*1.5');
+    const reward10 = getWaveEnemyStats(10).reward;
+    assertEqual(reward10, Math.round(14 + 10 * 1.5), 'getWaveEnemyStats: 웨이브 10 보상 = 14 + 10*1.5');
+
+    // --- applyExplosion 범위 피해 ---
+    enemies.length = 0;
+    const mockStyle = { body: '#fff', core: '#fff', outline: '#000', halo: 'rgba(255,255,255,0.5)' };
+    enemies.push({ x: 100, y: 100, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
+    enemies.push({ x: 500, y: 500, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
+    const mockProjectile = {
+        damage: 200,
+        explosionRadius: 200,
+        explosionColor: 'rgba(0,0,0,0)',
+        explosionHaloColor: '#fff',
+        explosionStrokeColor: null,
+        explosionLife: 0.1
+    };
+    applyExplosion(mockProjectile, 100, 100);
+    assertEqual(enemies.length, 1, 'applyExplosion: 범위(200px) 내 적 1마리 제거');
+    assert(enemies[0].x === 500, 'applyExplosion: 범위 밖 적(500,500)은 생존');
+
+    console.log('Unit tests passed ✓');
+}
+
+if (require.main === module) {
+    run();
+}
+
+module.exports = { run };


### PR DESCRIPTION
## Summary

- **#8 버그 수정**: 웨이브 ~1482에서 적 HP가 `Infinity`가 되어 절대 죽지 않는 버그 수정 — `WAVE_MAX=9999` 상한, `getWaveEnemyStats()` 내 `Math.min(..., Number.MAX_SAFE_INTEGER)` 적용
- **#3 밸런스 조정**: 후반 스케일링 개선 — `TOWER_DAMAGE_GROWTH` 2.5→1.5, `TOWER_UPGRADE_COST_MULTIPLIER` 2→1.6, `ENEMY_HP_GROWTH_RATE` 1.25→1.18, 골드 보상 웨이브 비례 증가(`14 + wave*1.5`)
- **#6 유닛 테스트**: `tests/unit.test.js` 신규 추가 — 9개 테스트 (피해 계산, 업그레이드 비용, 웨이브 스케일링, Infinity 방어, 폭발 범위)

## Test plan

- [x] `npm test` → smoke + unit 모두 통과 확인
- [ ] 브라우저에서 웨이브 1~10 플레이 — 초반 포탑 유효성 확인
- [ ] HUD 웨이브 입력에 9999 초과값 입력 → 9999로 제한 확인
- [ ] 웨이브 1500 이동 후 적이 정상적으로 처치되는지 확인 (기존: Infinity HP로 불사)

🤖 Generated with [Claude Code](https://claude.com/claude-code)