### PR TITLE
feat: 포탑 판매 + 골드 피드백 + 빌드 패널 인디케이터 (#5, #7, #9)

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,10 @@
 
         <div class="app-body">
             <div class="build-shell">
-                <button type="button" id="build-toggle" class="build-toggle" aria-expanded="true" aria-controls="build-panel" title="포탑 패널 접기">◀</button>
+                <button type="button" id="build-toggle" class="build-toggle" aria-expanded="true" aria-controls="build-panel" title="포탑 패널 접기">
+                    <span class="toggle-arrow">◀</span>
+                    <span id="selected-tower-indicator" class="selected-tower-indicator"></span>
+                </button>
                 <aside id="build-panel" class="build-panel">
                     <h2>포탑 제작</h2>
                     <p class="build-hint">왼쪽에서 포탑을 선택한 뒤 지형을 클릭하세요.</p>
@@ -88,6 +91,8 @@
                     <p>피해량: <span data-field="tower-damage">-</span></p>
                     <p>레벨: <span data-field="tower-level">-</span></p>
                     <p>업그레이드 비용: <span data-field="tower-upgrade-cost">-</span></p>
+                    <p>판매 환급: <span data-field="tower-sell-refund">-</span></p>
+                    <button type="button" id="sell-tower-button">판매</button>
                 </div>
                 <div id="enemy-stats" class="stats-panel card hidden">
                     <h3>적 정보</h3>

--- a/main.js
+++ b/main.js
@@ -492,7 +492,8 @@ const TOWER_STATS_FIELDS = {
     fireDelay: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-fire-delay"]') : null,
     damage: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-damage"]') : null,
     level: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-level"]') : null,
-    upgradeCost: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-upgrade-cost"]') : null
+    upgradeCost: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-upgrade-cost"]') : null,
+    sellRefund: TOWER_STATS_PANEL ? TOWER_STATS_PANEL.querySelector('[data-field="tower-sell-refund"]') : null
 };
 const ENEMY_STATS_FIELDS = {
     wave: ENEMY_STATS_PANEL ? ENEMY_STATS_PANEL.querySelector('[data-field="enemy-wave"]') : null,
@@ -808,6 +809,11 @@ function hideAllStats() {
         button.classList.toggle('active', isSelected);
         button.setAttribute('aria-pressed', String(isSelected));
     }
+    const indicator = document.getElementById('selected-tower-indicator');
+    if (indicator) {
+        const def = getTowerDefinition(typeId);
+        indicator.textContent = def ? def.label : '';
+    }
 }
 
 function populateTowerList() {
@@ -1005,6 +1011,10 @@ function updateTowerStatsFields() {
         const cost = selectedTower.upgradeCost;
         TOWER_STATS_FIELDS.upgradeCost.textContent = cost == null ? 'MAX' : formatNumber(cost);
     }
+    if (TOWER_STATS_FIELDS.sellRefund) {
+        const refund = Math.floor((selectedTower.spentGold || 0) * 0.5);
+        TOWER_STATS_FIELDS.sellRefund.textContent = formatNumber(refund);
+    }
 }
 
 function updateEnemyStatsFields() {
@@ -1178,6 +1188,7 @@ function upgradeTower(tower) {
         return false;
     }
     gold -= cost;
+    tower.spentGold = (tower.spentGold || 0) + cost;
     updateGoldUI();
     tower.level += 1;
     recalcTowerStats(tower);
@@ -1186,6 +1197,28 @@ function upgradeTower(tower) {
         updateTowerStatsFields();
     }
     return true;
+}
+
+function sellTower(tower) {
+    if (gameOver) return false;
+    const idx = towers.indexOf(tower);
+    if (idx === -1) return false;
+    const refund = Math.floor((tower.spentGold || 0) * 0.5);
+    towers.splice(idx, 1);
+    gold += refund;
+    updateGoldUI();
+    if (selectedTower === tower) hideTowerStats();
+    playSound('build');
+    return true;
+}
+
+function flashGoldInsufficient() {
+    if (!GOLD_LABEL) return;
+    const chip = GOLD_LABEL.closest('.stat-chip');
+    if (!chip) return;
+    chip.classList.remove('flash-insufficient');
+    void chip.offsetWidth;
+    chip.classList.add('flash-insufficient');
 }
 
 function showDefeatDialog() {
@@ -1275,7 +1308,8 @@ function createTowerData(x, y, typeId) {
         aimAngle: null,
         flashTimer: 0,
         recoil: 0,
-        auraOffset: Math.random() * Math.PI * 2
+        auraOffset: Math.random() * Math.PI * 2,
+        spentGold: def.cost || 0
     };
 }
 
@@ -2600,6 +2634,7 @@ canvas.addEventListener("click", event => {
     const towerDef = getTowerDefinition(selectedTowerType);
     const cost = towerDef.cost || 25;
     if (gold < cost) {
+        flashGoldInsufficient();
         return;
     }
 
@@ -2722,6 +2757,13 @@ GOLD_ADJUST_BUTTONS.forEach(button => {
     });
 });
 
+const SELL_TOWER_BUTTON = document.getElementById('sell-tower-button');
+if (SELL_TOWER_BUTTON) {
+    SELL_TOWER_BUTTON.addEventListener('click', () => {
+        if (selectedTower) sellTower(selectedTower);
+    });
+}
+
 if (RETRY_BUTTON) {
     RETRY_BUTTON.addEventListener('click', () => {
         resetGame();
@@ -2777,7 +2819,7 @@ if (WAVE_INPUT) {
 requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {
-    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, enemies };
+    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, sellTower, enemies, towers, gold: () => gold };
 }
 
 

--- a/style.css
+++ b/style.css
@@ -454,3 +454,58 @@ canvas {
     color: #f7fbff;
     font-weight: 600;
 }
+
+/* 판매 버튼 */
+#sell-tower-button {
+    margin-top: 8px;
+    width: 100%;
+    background: rgba(255, 131, 100, 0.12);
+    border: 1px solid rgba(255, 131, 100, 0.4);
+    border-radius: 999px;
+    padding: 7px 14px;
+    font-size: 14px;
+    color: var(--danger);
+    cursor: pointer;
+    transition: background var(--transition), border var(--transition);
+}
+
+#sell-tower-button:hover {
+    background: rgba(255, 131, 100, 0.25);
+    border-color: var(--danger);
+}
+
+/* 골드 부족 피드백 */
+@keyframes gold-flash {
+    0%   { border-color: var(--danger); background: rgba(255, 131, 100, 0.18); }
+    60%  { border-color: rgba(255, 131, 100, 0.7); background: rgba(255, 131, 100, 0.22); }
+    100% { border-color: rgba(255, 255, 255, 0.08); background: rgba(255, 255, 255, 0.04); }
+}
+
+.stat-chip.flash-insufficient {
+    animation: gold-flash 0.55s ease-out forwards;
+}
+
+/* 빌드 패널 접기 버튼 인디케이터 */
+.toggle-arrow,
+.selected-tower-indicator {
+    display: block;
+    line-height: 1;
+}
+
+.selected-tower-indicator {
+    display: none;
+    font-size: 10px;
+    font-weight: 700;
+    color: #09152b;
+    text-align: center;
+    max-width: 28px;
+    word-break: keep-all;
+}
+
+.build-shell.collapsed .toggle-arrow {
+    display: none;
+}
+
+.build-shell.collapsed .selected-tower-indicator {
+    display: block;
+}


### PR DESCRIPTION
## Summary

- **#5 포탑 판매**: `spentGold` 추적 → `sellTower()` 구현(환급 50%) → tower-stats 패널에 환급 금액 + 판매 버튼 추가
- **#7 골드 피드백**: 골드 부족 클릭 시 골드 HUD 칩 붉은색 플래시 (`gold-flash` 애니메이션)
- **#9 패널 인디케이터**: 빌드 패널 접힌 상태에서 현재 선택 포탑 이름 표시 (`#selected-tower-indicator`)

## Test plan

- [x] `npm test` 통과 확인
- [ ] 포탑 설치 후 클릭 → 우측 패널에 판매 버튼 + 환급 금액 표시 확인
- [ ] 업그레이드 여러 번 후 판매 → 환급금이 (설치비 + 업그레이드비 합계)의 50%인지 확인
- [ ] 골드 부족 상태에서 포탑 설치 시도 → 골드 HUD 칩 깜박임 확인
- [ ] 빌드 패널 접은 상태에서 포탑 선택 변경 → 접기 버튼에 포탑 이름 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)