### PR TITLE
fix: 게임 루프 안정성 + DOM null 안전성 + 오디오 에러 핸들링 + 보안 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;">
     <title>타워 디펜스 커맨드</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/main.js
+++ b/main.js
@@ -852,14 +852,22 @@ function populateTowerList() {
         const baseDamage = typeof def.baseDamage === 'number' ? def.baseDamage : 0;
         const fireDelay = typeof def.fireDelay === 'number' && def.fireDelay > 0 ? def.fireDelay : 1;
         const dps = baseDamage / fireDelay;
-        button.innerHTML = `
-            <span class="tower-name">${def.label}</span>
-            <span class="tower-meta">
-                <span>비용 ${formatNumber(cost)}</span>
-                <span>사거리 ${Math.round(range)}px</span>
-                <span>DPS ${formatNumber(Number(dps.toFixed(1)))}</span>
-            </span>
-        `;
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'tower-name';
+        nameSpan.textContent = def.label;
+
+        const metaSpan = document.createElement('span');
+        metaSpan.className = 'tower-meta';
+
+        const costSpan = document.createElement('span');
+        costSpan.textContent = '비용 ' + formatNumber(cost);
+        const rangeSpan = document.createElement('span');
+        rangeSpan.textContent = '사거리 ' + Math.round(range) + 'px';
+        const dpsSpan = document.createElement('span');
+        dpsSpan.textContent = 'DPS ' + formatNumber(Number(dps.toFixed(1)));
+
+        metaSpan.append(costSpan, rangeSpan, dpsSpan);
+        button.append(nameSpan, metaSpan);
         button.addEventListener('click', () => {
             if (selectedTowerType === id) {
                 return;
@@ -888,7 +896,7 @@ function setBuildPanelCollapsed(state, options = {}) {
     BUILD_CONTAINER.classList.toggle('collapsed', state);
     if (BUILD_TOGGLE) {
         BUILD_TOGGLE.setAttribute('aria-expanded', String(!state));
-        BUILD_TOGGLE.innerHTML = state ? '▶' : '◀';
+        BUILD_TOGGLE.textContent = state ? '▶' : '◀';
         BUILD_TOGGLE.setAttribute('title', state ? '포탑 패널 펼치기' : '포탑 패널 접기');
     }
 }


### PR DESCRIPTION
## Summary
- #12: 게임 루프 dt 클램핑 (0.1초 상한) + try-catch 추가
- #13: showDefeatDialog gameOver 플래그 선설정, WAVE_LABEL/LIVES_LABEL null 가드 5곳, canvas null 체크
- #14: AudioContext 생성 try-catch + suspended resume 처리
- #15: updateEnemyStatsFields에 enemies 배열 존재 확인
- #17: innerHTML → textContent/createElement 교체, CSP meta 태그 추가

Closes #12, Closes #13, Closes #14, Closes #15, Closes #17

## Test plan
- [x] npm test 통과
- [ ] 브라우저에서 게임 실행 확인
- [ ] 탭 전환 후 복귀 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)