### PR TITLE
perf+fix+test: 상태 초기화 + 렌더링 최적화 + 로직 최적화 + 테스트 확대

### DIFF
--- a/main.js
+++ b/main.js
@@ -2900,7 +2900,7 @@ buildStaticLayer();
 requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {
-    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, sellTower, enemies, towers, gold: () => gold };
+    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, sellTower, hexToRgba, applyAlpha, enemies, towers, gold: () => gold };
 }
 
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -79,7 +79,22 @@ function setupDom() {
         save: noop, restore: noop, font: '', textAlign: '', textBaseline: '',
         fillText: noop,
         createRadialGradient: () => ({ addColorStop: noop }),
-        createLinearGradient: () => ({ addColorStop: noop })
+        createLinearGradient: () => ({ addColorStop: noop }),
+        setLineDash: noop,
+        ellipse: noop,
+        resetTransform: noop,
+        globalCompositeOperation: 'source-over',
+        shadowColor: '',
+        shadowBlur: 0,
+        globalAlpha: 1,
+        lineCap: 'butt',
+        lineJoin: 'miter',
+        rotate: noop,
+        translate: noop,
+        closePath: noop,
+        setTransform: noop,
+        measureText: () => ({ width: 0 }),
+        drawImage: noop
     });
 
     delete require.cache[require.resolve('../main.js')];

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -77,7 +77,22 @@ function setupDom() {
         save: noop, restore: noop, font: '', textAlign: '', textBaseline: '',
         fillText: noop,
         createRadialGradient: () => ({ addColorStop: noop }),
-        createLinearGradient: () => ({ addColorStop: noop })
+        createLinearGradient: () => ({ addColorStop: noop }),
+        setLineDash: noop,
+        ellipse: noop,
+        resetTransform: noop,
+        globalCompositeOperation: 'source-over',
+        shadowColor: '',
+        shadowBlur: 0,
+        globalAlpha: 1,
+        lineCap: 'butt',
+        lineJoin: 'miter',
+        rotate: noop,
+        translate: noop,
+        closePath: noop,
+        setTransform: noop,
+        measureText: () => ({ width: 0 }),
+        drawImage: noop
     });
 
     delete require.cache[require.resolve('../main.js')];
@@ -104,7 +119,11 @@ function run() {
         getWaveEnemyCount,
         getWaveEnemyStats,
         applyExplosion,
-        enemies
+        sellTower,
+        hexToRgba,
+        applyAlpha,
+        enemies,
+        towers
     } = game;
 
     // --- calculateTowerDamage ---
@@ -119,6 +138,12 @@ function run() {
         parseFloat((20 * 1.5).toFixed(4)),
         'calculateTowerDamage: 레벨 2 피해는 baseDamage * TOWER_DAMAGE_GROWTH(1.5)'
     );
+    // 레벨 5 피해
+    assertEqual(
+        calculateTowerDamage(basicDef, 5),
+        parseFloat((20 * Math.pow(1.5, 4)).toFixed(4)),
+        'calculateTowerDamage: 레벨 5 피해는 baseDamage * 1.5^4'
+    );
 
     // --- calculateUpgradeCost ---
     const def40 = { baseUpgradeCost: 40 };
@@ -132,6 +157,9 @@ function run() {
         Math.round(40 * 1.6),
         'calculateUpgradeCost: 레벨 2 비용 = base * TOWER_UPGRADE_COST_MULTIPLIER(1.6)'
     );
+    // MAX_LEVEL(15) 업그레이드 비용 검증 - 함수 자체는 계산만 수행
+    const costAtMax = calculateUpgradeCost(def40, 15);
+    assert(costAtMax > 0, 'calculateUpgradeCost: 레벨 15에서도 비용 계산은 양수');
 
     // --- getWaveEnemyCount ---
     assertEqual(getWaveEnemyCount(1), 9, 'getWaveEnemyCount: 웨이브 1 = 8 + floor(1.5) = 9');
@@ -140,6 +168,7 @@ function run() {
     // --- getWaveEnemyStats HP 스케일링 ---
     const stats1 = getWaveEnemyStats(1);
     assertEqual(stats1.hp, 78, 'getWaveEnemyStats: 웨이브 1 체력 = ENEMY_BASE_HP(78)');
+    assertEqual(stats1.speed, 49, 'getWaveEnemyStats: 웨이브 1 속도 = ENEMY_SPEED(49)');
 
     const stats2 = getWaveEnemyStats(2);
     assertEqual(stats2.hp, Math.round(78 * 1.18), 'getWaveEnemyStats: 웨이브 2 체력 = 78 * 1.18');
@@ -155,8 +184,42 @@ function run() {
     const reward10 = getWaveEnemyStats(10).reward;
     assertEqual(reward10, Math.round(14 + 10 * 1.5), 'getWaveEnemyStats: 웨이브 10 보상 = 14 + 10*1.5');
 
+    // --- hexToRgba ---
+    // 6자리 hex
+    assertEqual(hexToRgba('#ff0000', 0.5), 'rgba(255, 0, 0, 0.5)', 'hexToRgba: 6자리 빨간색');
+    // 3자리 hex
+    assertEqual(hexToRgba('#f00', 0.5), 'rgba(255, 0, 0, 0.5)', 'hexToRgba: 3자리 빨간색');
+    // null 입력
+    assertEqual(hexToRgba(null, 0.5), 'rgba(255, 255, 255, 0.5)', 'hexToRgba: null 입력');
+
+    // --- applyAlpha ---
+    // hex 색상
+    assertEqual(applyAlpha('#00ff00', 0.3), hexToRgba('#00ff00', 0.3), 'applyAlpha: hex 색상 변환');
+    // null 색상
+    assert(applyAlpha(null, 0.5).includes('255, 255, 255'), 'applyAlpha: null 색상은 흰색 기본값');
+    // 일반 문자열
+    assertEqual(applyAlpha('blue', 0.5), 'blue', 'applyAlpha: 지원하지 않는 형식은 그대로 반환');
+
+    // --- sellTower ---
+    // 정상 판매
+    enemies.length = 0;
+    towers.length = 0;
+    const mockTower = {
+        x: 0, y: 0, worldX: 15, worldY: 15,
+        type: 'basic', level: 1, spentGold: 100,
+        cooldown: 0, activeBeam: null, heading: 0,
+        aimAngle: null, flashTimer: 0, recoil: 0,
+        auraOffset: 0, range: 165, fireDelay: 0.6,
+        damage: 20, upgradeCost: 40
+    };
+    towers.push(mockTower);
+    const soldResult = sellTower(mockTower);
+    assertEqual(soldResult, true, 'sellTower: 정상 판매 시 true 반환');
+    assertEqual(towers.length, 0, 'sellTower: 판매 후 towers 배열에서 제거');
+
     // --- applyExplosion 범위 피해 ---
     enemies.length = 0;
+    towers.length = 0;
     const mockStyle = { body: '#fff', core: '#fff', outline: '#000', halo: 'rgba(255,255,255,0.5)' };
     enemies.push({ x: 100, y: 100, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
     enemies.push({ x: 500, y: 500, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
@@ -172,7 +235,7 @@ function run() {
     assertEqual(enemies.length, 1, 'applyExplosion: 범위(200px) 내 적 1마리 제거');
     assert(enemies[0].x === 500, 'applyExplosion: 범위 밖 적(500,500)은 생존');
 
-    console.log('Unit tests passed ✓');
+    console.log('Unit tests passed');
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- #16: resetGame에 buildPanelUserOverride 초기화 + setWave에 hideTowerStats 추가
- #20: offscreen canvas 정적 레이어 분리 + applyAlpha 캐시 도입
- #21: findTarget Math.hypot→distSq, getTowerUpgradeCost 삭제, resize debounce, playNoise 캐시
- #22: FakeCanvas mock 보완 + unit.test.js 확장 + module.exports 확장

Closes #16, Closes #20, Closes #21, Closes #22

## Test plan
- [x] npm test 통과 (smoke + unit)
- [ ] 브라우저에서 게임 실행 확인
- [ ] 탭 전환 후 복귀 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)