### PR TITLE
feat: 복수 맵 / 경로 시스템 구현 (#4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,14 @@
         </div>
     </div>
 
+    <div id="map-select-overlay" class="overlay" role="dialog" aria-modal="true" aria-label="맵 선택">
+        <div class="overlay-content">
+            <h2>맵 선택</h2>
+            <div id="map-list"></div>
+            <button type="button" id="start-game-button" class="restart-button">시작</button>
+        </div>
+    </div>
+
     <div id="defeat-overlay" class="overlay hidden" role="dialog" aria-modal="true" aria-label="패배">
         <div class="overlay-content">
             <h2>패배했습니다</h2>

--- a/main.js
+++ b/main.js
@@ -424,38 +424,65 @@ const TOWER_ORDER = [
     'mortar'
 ];
 
-const waypoints = [
-    { x: -2, y: 8 },
-    { x: 2, y: 8 },
-    { x: 2, y: 4 },
-    { x: 10, y: 4 },
-    { x: 10, y: 12 },
-    { x: 18, y: 12 },
-    { x: 18, y: 6 },
-    { x: 26, y: 6 },
-    { x: 26, y: 14 },
-    { x: GRID_COLS + 1, y: 14 }
-].map(point => ({
-    x: point.x * TILE_SIZE + TILE_CENTER_OFFSET,
-    y: point.y * TILE_SIZE + TILE_CENTER_OFFSET
-}));
+const MAP_DEFINITIONS = {
+    map1: {
+        id: 'map1', name: '기본 맵', difficulty: '보통',
+        rawWaypoints: [
+            { x: -2, y: 8 }, { x: 2, y: 8 }, { x: 2, y: 4 },
+            { x: 10, y: 4 }, { x: 10, y: 12 }, { x: 18, y: 12 },
+            { x: 18, y: 6 }, { x: 26, y: 6 }, { x: 26, y: 14 },
+            { x: GRID_COLS + 1, y: 14 }
+        ]
+    },
+    map2: {
+        id: 'map2', name: 'S자 맵', difficulty: '어려움',
+        rawWaypoints: [
+            { x: -2, y: 3 }, { x: 8, y: 3 }, { x: 8, y: 17 },
+            { x: 16, y: 17 }, { x: 16, y: 3 }, { x: 24, y: 3 },
+            { x: 24, y: 17 }, { x: GRID_COLS + 1, y: 17 }
+        ]
+    },
+    map3: {
+        id: 'map3', name: '나선 맵', difficulty: '쉬움',
+        rawWaypoints: [
+            { x: -2, y: 10 }, { x: 4, y: 10 }, { x: 4, y: 2 },
+            { x: 26, y: 2 }, { x: 26, y: 18 }, { x: 4, y: 18 },
+            { x: 4, y: 12 }, { x: 20, y: 12 }, { x: 20, y: 6 },
+            { x: GRID_COLS + 1, y: 6 }
+        ]
+    }
+};
 
-const pathTiles = new Set();
-for (let i = 0; i < waypoints.length - 1; i++) {
-    const a = gridFromPosition(waypoints[i]);
-    const b = gridFromPosition(waypoints[i + 1]);
-    if (a.x === b.x) {
-        const step = Math.sign(b.y - a.y) || 1;
-        for (let y = a.y; y !== b.y + step; y += step) {
-            pathTiles.add(`${a.x},${y}`);
-        }
-    } else if (a.y === b.y) {
-        const step = Math.sign(b.x - a.x) || 1;
-        for (let x = a.x; x !== b.x + step; x += step) {
-            pathTiles.add(`${x},${a.y}`);
+let activeMapId = 'map1';
+let waypoints = [];
+let pathTiles = new Set();
+
+function buildMapData(mapId) {
+    const mapDef = MAP_DEFINITIONS[mapId] || MAP_DEFINITIONS['map1'];
+    waypoints = mapDef.rawWaypoints.map(point => ({
+        x: point.x * TILE_SIZE + TILE_CENTER_OFFSET,
+        y: point.y * TILE_SIZE + TILE_CENTER_OFFSET
+    }));
+    pathTiles = new Set();
+    for (let i = 0; i < waypoints.length - 1; i++) {
+        const a = gridFromPosition(waypoints[i]);
+        const b = gridFromPosition(waypoints[i + 1]);
+        if (a.x === b.x) {
+            const step = Math.sign(b.y - a.y) || 1;
+            for (let y = a.y; y !== b.y + step; y += step) {
+                pathTiles.add(`${a.x},${y}`);
+            }
+        } else if (a.y === b.y) {
+            const step = Math.sign(b.x - a.x) || 1;
+            for (let x = a.x; x !== b.x + step; x += step) {
+                pathTiles.add(`${x},${a.y}`);
+            }
         }
     }
+    staticLayer = null;
 }
+
+buildMapData(activeMapId);
 
 const towers = [];
 const enemies = [];
@@ -523,6 +550,9 @@ const WAVE_PREVIEW_FIELDS = WAVE_PREVIEW_PANEL ? {
 const DEFEAT_OVERLAY = document.getElementById('defeat-overlay');
 const RETRY_BUTTON = document.getElementById('retry-button');
 const CANCEL_RETRY_BUTTON = document.getElementById('cancel-retry-button');
+const MAP_SELECT_OVERLAY = document.getElementById('map-select-overlay');
+const MAP_LIST_CONTAINER = document.getElementById('map-list');
+const START_GAME_BUTTON = document.getElementById('start-game-button');
 const BUILD_PANEL = document.getElementById('build-panel');
 const BUILD_TOGGLE = document.getElementById('build-toggle');
 const BUILD_CONTAINER = document.querySelector('.build-shell');
@@ -1275,7 +1305,53 @@ function hideDefeatDialog() {
     DEFEAT_OVERLAY.classList.add('hidden');
 }
 
+function showMapSelectOverlay() {
+    if (!MAP_SELECT_OVERLAY) {
+        return;
+    }
+    paused = true;
+    MAP_SELECT_OVERLAY.classList.remove('hidden');
+}
+
+function hideMapSelectOverlay() {
+    if (!MAP_SELECT_OVERLAY) {
+        return;
+    }
+    MAP_SELECT_OVERLAY.classList.add('hidden');
+}
+
+function populateMapList() {
+    if (!MAP_LIST_CONTAINER) {
+        return;
+    }
+    MAP_LIST_CONTAINER.innerHTML = '';
+    for (const mapDef of Object.values(MAP_DEFINITIONS)) {
+        const card = document.createElement('button');
+        card.type = 'button';
+        card.className = 'map-card' + (mapDef.id === activeMapId ? ' selected' : '');
+        card.dataset.mapId = mapDef.id;
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'map-card-name';
+        nameEl.textContent = mapDef.name;
+
+        const diffEl = document.createElement('span');
+        diffEl.className = 'map-card-difficulty';
+        diffEl.textContent = '난이도: ' + mapDef.difficulty;
+
+        card.append(nameEl, diffEl);
+        card.addEventListener('click', () => {
+            activeMapId = mapDef.id;
+            const allCards = MAP_LIST_CONTAINER.querySelectorAll('.map-card');
+            allCards.forEach(c => c.classList.toggle('selected', c.dataset.mapId === activeMapId));
+        });
+        MAP_LIST_CONTAINER.appendChild(card);
+    }
+}
+
 function resetGame() {
+    buildMapData(activeMapId);
+    staticLayer = null;
     gold = 100;
     lives = 20;
     wave = 1;
@@ -2854,13 +2930,25 @@ if (SELL_TOWER_BUTTON) {
 
 if (RETRY_BUTTON) {
     RETRY_BUTTON.addEventListener('click', () => {
+        hideDefeatDialog();
         resetGame();
+        populateMapList();
+        showMapSelectOverlay();
     });
 }
 
 if (CANCEL_RETRY_BUTTON) {
     CANCEL_RETRY_BUTTON.addEventListener('click', () => {
         hideDefeatDialog();
+    });
+}
+
+if (START_GAME_BUTTON) {
+    START_GAME_BUTTON.addEventListener('click', () => {
+        hideMapSelectOverlay();
+        resetGame();
+        buildStaticLayer();
+        paused = false;
     });
 }
 
@@ -2909,7 +2997,8 @@ if (WAVE_INPUT) {
     WAVE_INPUT.value = wave;
 }
 
-buildStaticLayer();
+populateMapList();
+showMapSelectOverlay();
 requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {

--- a/style.css
+++ b/style.css
@@ -509,3 +509,69 @@ canvas {
 .build-shell.collapsed .selected-tower-indicator {
     display: block;
 }
+
+/* 맵 선택 오버레이 */
+#map-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 16px 0;
+    min-width: 320px;
+}
+
+.map-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 14px 18px;
+    cursor: pointer;
+    text-align: left;
+    color: var(--text-main);
+    width: 100%;
+    transition: transform var(--transition), border var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.map-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(106, 168, 255, 0.5);
+    box-shadow: 0 10px 20px rgba(12, 18, 27, 0.4);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.map-card.selected {
+    background: rgba(106, 168, 255, 0.12);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft), 0 14px 24px rgba(19, 58, 110, 0.45);
+}
+
+.map-card-name {
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.map-card-difficulty {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.restart-button {
+    margin-top: 6px;
+    background: var(--accent);
+    border: 1px solid var(--accent-strong);
+    border-radius: 999px;
+    padding: 10px 32px;
+    font-size: 15px;
+    font-weight: 600;
+    color: #071432;
+    cursor: pointer;
+    transition: background var(--transition), border var(--transition), transform var(--transition);
+}
+
+.restart-button:hover {
+    background: var(--accent-strong);
+    transform: translateY(-1px);
+}


### PR DESCRIPTION
## Summary
- MAP_DEFINITIONS로 3개 맵 정의 (기본/S자/나선)
- waypoints/pathTiles를 동적으로 빌드하는 buildMapData() 추가
- 게임 시작 전 맵 선택 모달 UI (글래스모피즘 스타일)
- 리셋/패배 시 맵 선택 화면으로 복귀

Closes #4

## Test plan
- [x] `npm test` 통과
- [ ] 3개 맵 각각에서 경로 올바르게 렌더
- [ ] 맵 전환 후 포탑 설치/경로 충돌 판단 정상
- [ ] 패배 후 다시 시작 시 맵 선택 화면 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)