### PR TITLE
fix: Batch C - 반응형/접근성/테스트 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,17 +16,17 @@
             <div class="bar-left">
                 <h1 class="brand">타워 디펜스 커맨드</h1>
                 <div class="stat-block">
-                    <div class="stat-chip" aria-live="polite" aria-atomic="true">
+                    <div class="stat-chip">
                         <span class="stat-label">웨이브</span>
-                        <span class="stat-value" id="wave">1</span>
+                        <span class="stat-value" id="wave" aria-live="polite">1</span>
                     </div>
-                    <div class="stat-chip" aria-live="polite" aria-atomic="true">
+                    <div class="stat-chip">
                         <span class="stat-label">생명력</span>
-                        <span class="stat-value" id="lives">20</span>
+                        <span class="stat-value" id="lives" aria-live="polite">20</span>
                     </div>
-                    <div class="stat-chip" aria-live="polite" aria-atomic="true">
+                    <div class="stat-chip">
                         <span class="stat-label">골드</span>
-                        <span class="stat-value" id="gold">100</span>
+                        <span class="stat-value" id="gold" aria-live="polite">100</span>
                     </div>
                 </div>
             </div>
@@ -66,7 +66,7 @@
                 <aside id="build-panel" class="build-panel">
                     <h2>포탑 제작</h2>
                     <p class="build-hint">왼쪽에서 포탑을 선택한 뒤 지형을 클릭하세요.</p>
-                    <div id="tower-list" class="tower-list" role="radiogroup" aria-label="포탑 선택"></div>
+                    <div id="tower-list" class="tower-list" role="toolbar" aria-label="포탑 선택"></div>
                 </aside>
             </div>
 

--- a/main.js
+++ b/main.js
@@ -1334,12 +1334,19 @@ function hideDefeatDialog() {
     }
 }
 
+let _mapSelectPreviousFocus = null;
+
 function showMapSelectOverlay() {
     if (!MAP_SELECT_OVERLAY) {
         return;
     }
+    _mapSelectPreviousFocus = document.activeElement;
     paused = true;
     MAP_SELECT_OVERLAY.classList.remove('hidden');
+    const firstFocusable = MAP_SELECT_OVERLAY.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (firstFocusable) {
+        firstFocusable.focus();
+    }
 }
 
 function hideMapSelectOverlay() {
@@ -1347,6 +1354,10 @@ function hideMapSelectOverlay() {
         return;
     }
     MAP_SELECT_OVERLAY.classList.add('hidden');
+    if (_mapSelectPreviousFocus && typeof _mapSelectPreviousFocus.focus === 'function') {
+        _mapSelectPreviousFocus.focus();
+        _mapSelectPreviousFocus = null;
+    }
 }
 
 function populateMapList() {
@@ -1368,11 +1379,16 @@ function populateMapList() {
         diffEl.className = 'map-card-difficulty';
         diffEl.textContent = '난이도: ' + mapDef.difficulty;
 
+        card.setAttribute('aria-pressed', String(mapDef.id === activeMapId));
         card.append(nameEl, diffEl);
         card.addEventListener('click', () => {
             activeMapId = mapDef.id;
             const allCards = MAP_LIST_CONTAINER.querySelectorAll('.map-card');
-            allCards.forEach(c => c.classList.toggle('selected', c.dataset.mapId === activeMapId));
+            allCards.forEach(c => {
+                const isSelected = c.dataset.mapId === activeMapId;
+                c.classList.toggle('selected', isSelected);
+                c.setAttribute('aria-pressed', String(isSelected));
+            });
         });
         MAP_LIST_CONTAINER.appendChild(card);
     }
@@ -3048,9 +3064,37 @@ if (DEFEAT_OVERLAY) {
     });
 
     DEFEAT_OVERLAY.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            hideDefeatDialog();
+            return;
+        }
         if (event.key !== 'Tab') return;
         const focusable = Array.from(
             DEFEAT_OVERLAY.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+        ).filter(el => !el.disabled);
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey) {
+            if (document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            }
+        } else {
+            if (document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+    });
+}
+
+if (MAP_SELECT_OVERLAY) {
+    MAP_SELECT_OVERLAY.addEventListener('keydown', event => {
+        if (event.key !== 'Tab') return;
+        const focusable = Array.from(
+            MAP_SELECT_OVERLAY.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
         ).filter(el => !el.disabled);
         if (focusable.length === 0) return;
         const first = focusable[0];
@@ -3129,7 +3173,18 @@ showMapSelectOverlay();
 requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {
-    module.exports = { calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats, applyExplosion, sellTower, hexToRgba, applyAlpha, enemies, towers, gold: () => gold };
+    module.exports = {
+        calculateTowerDamage, calculateUpgradeCost, getWaveEnemyCount, getWaveEnemyStats,
+        applyExplosion, sellTower, hexToRgba, applyAlpha, enemies, towers, gold: () => gold,
+        canBuildAt, findTarget, createTowerData, upgradeTower, damageEnemy, damageEnemyAtIndex,
+        pickEnemyType, pathTiles, ENEMY_TYPE_DEFINITIONS, GRID_COLS, GRID_ROWS, TOWER_MAX_LEVEL,
+        projectiles,
+        setGold: (v) => { gold = v; },
+        getGameOver: () => gameOver,
+        setGameOver: (v) => { gameOver = v; },
+        getEnemiesToSpawn: () => enemiesToSpawn,
+        setEnemiesToSpawn: (v) => { enemiesToSpawn = v; }
+    };
 }
 
 

--- a/style.css
+++ b/style.css
@@ -179,8 +179,8 @@ body {
 }
 
 .icon-button {
-    width: 38px;
-    height: 38px;
+    width: 44px;
+    height: 44px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -214,7 +214,7 @@ body {
     position: absolute;
     top: 16px;
     right: -16px;
-    width: 32px;
+    width: 44px;
     height: 64px;
     border-radius: 16px 0 0 16px;
     background: var(--accent);
@@ -442,6 +442,18 @@ canvas {
         height: 44px;
         border-radius: 12px;
         transform: none !important;
+    }
+    .stage-area {
+        width: 100%;
+    }
+    .canvas-wrapper {
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    canvas {
+        max-width: 100%;
+        height: auto;
     }
 }
 
@@ -691,5 +703,14 @@ canvas {
         width: 40px;
         height: 40px;
         border-radius: 10px;
+    }
+}
+
+/* ── Reduced motion preference ── */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
     }
 }

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -123,7 +123,20 @@ function run() {
         hexToRgba,
         applyAlpha,
         enemies,
-        towers
+        towers,
+        canBuildAt,
+        findTarget,
+        createTowerData,
+        upgradeTower,
+        damageEnemy,
+        damageEnemyAtIndex,
+        pickEnemyType,
+        pathTiles,
+        ENEMY_TYPE_DEFINITIONS,
+        GRID_COLS,
+        GRID_ROWS,
+        TOWER_MAX_LEVEL,
+        projectiles
     } = game;
 
     // --- calculateTowerDamage ---
@@ -184,6 +197,25 @@ function run() {
     const reward10 = getWaveEnemyStats(10).reward;
     assertEqual(reward10, Math.round(14 + 10 * 1.5), 'getWaveEnemyStats: 웨이브 10 보상 = 14 + 10*1.5');
 
+    // --- getWaveEnemyStats: armored type ---
+    const armoredType = ENEMY_TYPE_DEFINITIONS.find(t => t.id === 'armored');
+    const armoredStats = getWaveEnemyStats(1, armoredType);
+    assertEqual(armoredStats.hp, Math.round(78 * 3.0), 'getWaveEnemyStats: 장갑 웨이브 1 체력 = 78 * 3.0');
+    assertEqual(armoredStats.speed, Math.round(49 * 0.6), 'getWaveEnemyStats: 장갑 속도 = 49 * 0.6');
+    assertEqual(armoredStats.reward, Math.round((14 + 1 * 1.5) * 2.0), 'getWaveEnemyStats: 장갑 보상 = base * 2.0');
+
+    // --- getWaveEnemyStats: fast type ---
+    const fastType = ENEMY_TYPE_DEFINITIONS.find(t => t.id === 'fast');
+    const fastStats = getWaveEnemyStats(1, fastType);
+    assertEqual(fastStats.hp, Math.round(78 * 0.4), 'getWaveEnemyStats: 고속 웨이브 1 체력 = 78 * 0.4');
+    assertEqual(fastStats.speed, Math.round(49 * 2.5), 'getWaveEnemyStats: 고속 속도 = 49 * 2.5');
+
+    // --- getWaveEnemyStats: boss type ---
+    const bossType = ENEMY_TYPE_DEFINITIONS.find(t => t.id === 'boss');
+    const bossStats = getWaveEnemyStats(1, bossType);
+    assertEqual(bossStats.hp, Math.round(78 * 12.0), 'getWaveEnemyStats: 보스 웨이브 1 체력 = 78 * 12.0');
+    assertEqual(bossStats.reward, Math.round((14 + 1 * 1.5) * 8.0), 'getWaveEnemyStats: 보스 보상 = base * 8.0');
+
     // --- hexToRgba ---
     // 6자리 hex
     assertEqual(hexToRgba('#ff0000', 0.5), 'rgba(255, 0, 0, 0.5)', 'hexToRgba: 6자리 빨간색');
@@ -199,6 +231,11 @@ function run() {
     assert(applyAlpha(null, 0.5).includes('255, 255, 255'), 'applyAlpha: null 색상은 흰색 기본값');
     // 일반 문자열
     assertEqual(applyAlpha('blue', 0.5), 'blue', 'applyAlpha: 지원하지 않는 형식은 그대로 반환');
+    // rgba 입력
+    const rgbaResult = applyAlpha('rgba(100, 200, 50, 0.8)', 0.3);
+    assert(rgbaResult.includes('100'), 'applyAlpha: rgba 입력 시 R 값 유지');
+    assert(rgbaResult.includes('200'), 'applyAlpha: rgba 입력 시 G 값 유지');
+    assert(rgbaResult.includes('0.3'), 'applyAlpha: rgba 입력 시 알파 값 교체');
 
     // --- sellTower ---
     // 정상 판매
@@ -213,14 +250,142 @@ function run() {
         damage: 20, upgradeCost: 40
     };
     towers.push(mockTower);
+    game.setGold(500);
+    const goldBefore = game.gold();
     const soldResult = sellTower(mockTower);
     assertEqual(soldResult, true, 'sellTower: 정상 판매 시 true 반환');
     assertEqual(towers.length, 0, 'sellTower: 판매 후 towers 배열에서 제거');
+    const expectedRefund = Math.floor(100 * 0.5);
+    assertEqual(game.gold(), goldBefore + expectedRefund, 'sellTower: 판매 시 50% 골드 환급');
 
-    // --- applyExplosion 범위 피해 ---
+    // sellTower: gameOver 시 판매 불가
+    enemies.length = 0;
+    towers.length = 0;
+    const mockTower2 = {
+        x: 1, y: 1, worldX: 45, worldY: 45,
+        type: 'basic', level: 1, spentGold: 100,
+        cooldown: 0, activeBeam: null, heading: 0,
+        aimAngle: null, flashTimer: 0, recoil: 0,
+        auraOffset: 0, range: 165, fireDelay: 0.6,
+        damage: 20, upgradeCost: 40
+    };
+    towers.push(mockTower2);
+    game.setGameOver(true);
+    const sellWhenOver = sellTower(mockTower2);
+    assertEqual(sellWhenOver, false, 'sellTower: gameOver 상태에서 판매 불가');
+    assertEqual(towers.length, 1, 'sellTower: gameOver 시 towers 배열 유지');
+    game.setGameOver(false);
+
+    // --- canBuildAt ---
+    enemies.length = 0;
+    towers.length = 0;
+    // 경계 밖 검사
+    assertEqual(canBuildAt(-1, 0), false, 'canBuildAt: x < 0 은 건설 불가');
+    assertEqual(canBuildAt(0, -1), false, 'canBuildAt: y < 0 은 건설 불가');
+    assertEqual(canBuildAt(GRID_COLS, 0), false, 'canBuildAt: x >= GRID_COLS 은 건설 불가');
+    assertEqual(canBuildAt(0, GRID_ROWS), false, 'canBuildAt: y >= GRID_ROWS 은 건설 불가');
+
+    // 경로 위 건설 불가
+    const testPathKey = '5,5';
+    pathTiles.add(testPathKey);
+    assertEqual(canBuildAt(5, 5), false, 'canBuildAt: 경로 타일 위에 건설 불가');
+    pathTiles.delete(testPathKey);
+
+    // 타워 위 건설 불가
+    towers.push({ x: 3, y: 3 });
+    assertEqual(canBuildAt(3, 3), false, 'canBuildAt: 기존 타워 위에 건설 불가');
+    towers.length = 0;
+
+    // 빈 타일에 건설 가능 (경로 및 타워 없는 좌표)
+    pathTiles.delete('1,1');
+    assertEqual(canBuildAt(1, 1), true, 'canBuildAt: 빈 타일에 건설 가능');
+    towers.length = 0;
+
+    // --- createTowerData ---
+    enemies.length = 0;
+    towers.length = 0;
+    const towerData = createTowerData(2, 3, 'basic');
+    assertEqual(towerData.type, 'basic', 'createTowerData: 타입 필드 확인');
+    assertEqual(towerData.x, 2, 'createTowerData: x 좌표');
+    assertEqual(towerData.y, 3, 'createTowerData: y 좌표');
+    assertEqual(towerData.level, 1, 'createTowerData: 초기 레벨 = 1');
+    assertEqual(towerData.cooldown, 0, 'createTowerData: 초기 쿨다운 = 0');
+    assert(towerData.range > 0, 'createTowerData: 사거리 > 0');
+    assert(towerData.damage > 0, 'createTowerData: 피해량 > 0');
+    assert(towerData.worldX > 0, 'createTowerData: worldX 계산됨');
+    assert(towerData.worldY > 0, 'createTowerData: worldY 계산됨');
+    assert(towerData.spentGold > 0, 'createTowerData: spentGold = cost');
+
+    // --- upgradeTower ---
+    enemies.length = 0;
+    towers.length = 0;
+    game.setGold(10000);
+    const upgTower = createTowerData(4, 4, 'basic');
+    towers.push(upgTower);
+    const upgResult = upgradeTower(upgTower);
+    assertEqual(upgResult, true, 'upgradeTower: 골드 충분 시 업그레이드 성공');
+    assertEqual(upgTower.level, 2, 'upgradeTower: 업그레이드 후 레벨 2');
+
+    // upgradeTower: 골드 부족
+    game.setGold(0);
+    const upgFail = upgradeTower(upgTower);
+    assertEqual(upgFail, false, 'upgradeTower: 골드 부족 시 실패');
+    assertEqual(upgTower.level, 2, 'upgradeTower: 골드 부족 시 레벨 유지');
+
+    // upgradeTower: 최대 레벨
+    game.setGold(999999);
+    upgTower.level = TOWER_MAX_LEVEL;
+    const upgMax = upgradeTower(upgTower);
+    assertEqual(upgMax, false, 'upgradeTower: 최대 레벨에서 업그레이드 불가');
+    assertEqual(upgTower.level, TOWER_MAX_LEVEL, 'upgradeTower: 최대 레벨 유지');
+    towers.length = 0;
+
+    // --- findTarget ---
     enemies.length = 0;
     towers.length = 0;
     const mockStyle = { body: '#fff', core: '#fff', outline: '#000', halo: 'rgba(255,255,255,0.5)' };
+    const testTower = { worldX: 100, worldY: 100, range: 150 };
+
+    // 사거리 내 적
+    enemies.push({ x: 120, y: 120, hp: 50, maxHp: 50, reward: 10, waveIndex: 1, style: mockStyle, waypoint: 2 });
+    const target = findTarget(testTower);
+    assert(target !== null, 'findTarget: 사거리 내 적 발견');
+    assertEqual(target.x, 120, 'findTarget: 올바른 적 반환');
+
+    // 사거리 밖 적만 존재
+    enemies.length = 0;
+    enemies.push({ x: 900, y: 900, hp: 50, maxHp: 50, reward: 10, waveIndex: 1, style: mockStyle, waypoint: 0 });
+    const noTarget = findTarget(testTower);
+    assertEqual(noTarget, null, 'findTarget: 사거리 밖 적은 타겟 안됨');
+    enemies.length = 0;
+
+    // --- damageEnemy: kill ---
+    enemies.length = 0;
+    towers.length = 0;
+    game.setGold(0);
+    const killEnemy = { x: 50, y: 50, hp: 10, maxHp: 10, reward: 20, waveIndex: 1, style: mockStyle, waypoint: 0 };
+    enemies.push(killEnemy);
+    const killed = damageEnemy(killEnemy, 100);
+    assertEqual(killed, true, 'damageEnemy: 치명적 피해 시 true 반환');
+    assertEqual(enemies.length, 0, 'damageEnemy: 적 제거됨');
+    assertEqual(game.gold(), 20, 'damageEnemy: 적 처치 시 골드 획득');
+
+    // --- damageEnemy: no-kill ---
+    enemies.length = 0;
+    game.setGold(0);
+    const tankEnemy = { x: 60, y: 60, hp: 200, maxHp: 200, reward: 15, waveIndex: 1, style: mockStyle, waypoint: 0 };
+    enemies.push(tankEnemy);
+    const notKilled = damageEnemy(tankEnemy, 50);
+    assertEqual(notKilled, false, 'damageEnemy: 비치명적 피해 시 false 반환');
+    assertEqual(enemies.length, 1, 'damageEnemy: 적 생존');
+    assertEqual(tankEnemy.hp, 150, 'damageEnemy: HP 감소 확인');
+    assertEqual(game.gold(), 0, 'damageEnemy: 미처치 시 골드 미획득');
+    enemies.length = 0;
+
+    // --- applyExplosion 범위 피해 + 골드 보상 ---
+    enemies.length = 0;
+    towers.length = 0;
+    game.setGold(0);
     enemies.push({ x: 100, y: 100, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
     enemies.push({ x: 500, y: 500, hp: 100, maxHp: 100, reward: 14, waveIndex: 1, style: mockStyle, waypoint: 0 });
     const mockProjectile = {
@@ -234,6 +399,8 @@ function run() {
     applyExplosion(mockProjectile, 100, 100);
     assertEqual(enemies.length, 1, 'applyExplosion: 범위(200px) 내 적 1마리 제거');
     assert(enemies[0].x === 500, 'applyExplosion: 범위 밖 적(500,500)은 생존');
+    assertEqual(game.gold(), 14, 'applyExplosion: 처치된 적의 골드 보상 획득');
+    enemies.length = 0;
 
     console.log('Unit tests passed');
 }


### PR DESCRIPTION
## Summary
- **#36**: 768-960px 반응형 레이아웃 갭 수정 — canvas wrapper에 `width: 100%`, `overflow-x: auto` 추가
- **#37**: `prefers-reduced-motion` 미디어 쿼리 추가 + 터치 타겟(`.icon-button`, `.build-toggle`) 38/32px → 44px
- **#38**: 패배 오버레이에 Escape 키 닫기 핸들러 추가 + 맵 선택 오버레이 포커스 트랩 구현
- **#39**: `role="radiogroup"` → `role="toolbar"`, `aria-live` 를 `.stat-chip` → `.stat-value` 이동, 맵 카드에 `aria-pressed` 속성 추가
- **#41**: 핵심 게임 함수 테스트 커버리지 확대 (27 → 74 assertions): canBuildAt, findTarget, createTowerData, upgradeTower, damageEnemy, 적 유형별 stats 등

Closes #36, Closes #37, Closes #38, Closes #39, Closes #41

## Test plan
- [x] `npm test` 통과 (smoke + unit)
- [ ] 960px 이하에서 canvas 가로 스크롤 확인
- [ ] 44px 터치 타겟 크기 확인
- [ ] prefers-reduced-motion 미디어 쿼리 동작 확인
- [ ] 패배 오버레이에서 Escape 키로 닫기 확인
- [ ] 맵 선택 오버레이에서 Tab 포커스 트랩 동작 확인
- [ ] 스크린 리더에서 aria-live, aria-pressed 속성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)