### PR TITLE
fix: 보안 강화 + 코드 정리 (#30, #33, #35, #43, #44)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self';">
     <title>타워 디펜스 커맨드</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/main.js
+++ b/main.js
@@ -598,7 +598,7 @@ function ensureAudioContext() {
         masterGain.connect(audioContext.destination);
         return audioContext;
     } catch (e) {
-        console.warn('AudioContext 생성 실패:', e);
+        console.warn('AudioContext 생성 실패:', e.message);
         audioContext = null;
         masterGain = null;
         return null;
@@ -722,7 +722,7 @@ function playSound(name) {
     try {
         player();
     } catch (error) {
-        console.warn('사운드 재생 실패:', error);
+        console.warn('사운드 재생 실패:', error.message);
     }
 }
 
@@ -865,7 +865,7 @@ function hideAllStats() {
     hideEnemyStats();
 }
 
-﻿function setSelectedTowerButton(typeId) {
+function setSelectedTowerButton(typeId) {
     if (!TOWER_SELECTOR_BUTTONS || TOWER_SELECTOR_BUTTONS.length === 0) {
         return;
     }
@@ -1055,8 +1055,6 @@ function setWave(targetWave) {
     const desiredWave = Math.max(1, Math.min(WAVE_MAX, Math.floor(targetWave)));
     clearCurrentWave();
     hideTowerStats();
-    selectedTowerType = DEFAULT_TOWER_TYPE;
-    setSelectedTowerButton(selectedTowerType);
     wave = desiredWave;
     if (WAVE_LABEL) WAVE_LABEL.textContent = wave;
     if (WAVE_INPUT) {
@@ -1309,6 +1307,8 @@ function showDefeatDialog() {
     }
     gameOver = true;
     paused = true;
+    render();
+    stopLoop();
     clearCurrentWave();
     selectedTowerType = DEFAULT_TOWER_TYPE;
     setSelectedTowerButton(selectedTowerType);
@@ -3053,6 +3053,7 @@ if (START_GAME_BUTTON) {
         resetGame();
         buildStaticLayer();
         paused = false;
+        startLoop();
     });
 }
 
@@ -3143,6 +3144,7 @@ document.addEventListener("keydown", event => {
 
 let elapsedTime = 0;
 let lastTime = performance.now();
+let rafHandle = 0;
 function loop(timestamp) {
     try {
         const rawDt = (timestamp - lastTime) / 1000;
@@ -3155,11 +3157,23 @@ function loop(timestamp) {
         }
         render();
     } catch (e) {
-        console.error('Game loop error:', e);
+        console.error('Game loop error:', e.message);
     }
-    requestAnimationFrame(loop);
+    rafHandle = requestAnimationFrame(loop);
 }
 
+function stopLoop() {
+    if (rafHandle) {
+        cancelAnimationFrame(rafHandle);
+        rafHandle = 0;
+    }
+}
+
+function startLoop() {
+    stopLoop();
+    lastTime = performance.now();
+    rafHandle = requestAnimationFrame(loop);
+}
 
 updateSpeedControls();
 updateWavePreview();
@@ -3170,7 +3184,7 @@ if (WAVE_INPUT) {
 
 populateMapList();
 showMapSelectOverlay();
-requestAnimationFrame(loop);
+rafHandle = requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {
     module.exports = {


### PR DESCRIPTION
## Summary
- #30: CSP에 script-src, object-src, base-uri 명시 추가
- #33: setWave()에서 불필요한 selectedTowerType 초기화 제거
- #35: main.js 중간 BOM 문자 제거
- #43: RAF 핸들 저장 + stopLoop/startLoop 함수 추가
- #44: console.error/warn에서 에러 객체 대신 e.message만 출력

Closes #30, Closes #33, Closes #35, Closes #43, Closes #44

## Test plan
- [x] npm test 통과
- [x] main.js + index.html만 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)