### PR TITLE
fix: batch-a 인프라 버그 + 보안 개선 (#50, #51, #52, #54, #62)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self';">
+    <!-- NOTE: 서버 배포 시 HTTP 헤더로 CSP 전환 권장 (frame-ancestors 'none' 추가 가능) -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self'; connect-src 'none'; form-action 'none'; frame-src 'none';">
     <title>타워 디펜스 커맨드</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/main.js
+++ b/main.js
@@ -575,10 +575,18 @@ let soundMuted = false;
 
 function ensureAudioContext() {
     if (audioContext) {
-        if (audioContext.state === 'suspended') {
-            audioContext.resume().catch(() => {});
+        if (audioContext.state === 'closed') {
+            audioContext = null;
+            masterGain = null;
+            cachedNoiseBuffer = null;
+            cachedNoiseDuration = 0;
+            // fall through to create new context
+        } else {
+            if (audioContext.state === 'suspended') {
+                audioContext.resume().catch(() => {});
+            }
+            return audioContext;
         }
-        return audioContext;
     }
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     if (!AudioCtx) {
@@ -962,7 +970,8 @@ function setBuildPanelCollapsed(state, options = {}) {
     }
     if (BUILD_TOGGLE) {
         BUILD_TOGGLE.setAttribute('aria-expanded', String(!state));
-        BUILD_TOGGLE.textContent = state ? '▶' : '◀';
+        const arrow = BUILD_TOGGLE.querySelector('.toggle-arrow');
+        if (arrow) arrow.textContent = state ? '▶' : '◀';
         BUILD_TOGGLE.setAttribute('title', state ? '포탑 패널 펼치기' : '포탑 패널 접기');
     }
 }
@@ -1263,6 +1272,7 @@ function getEnemyAtPoint(px, py) {
 }
 
 function upgradeTower(tower) {
+    if (gameOver) return false;
     ensureTowerMetadata(tower);
     if (tower.level >= TOWER_MAX_LEVEL) {
         return false;
@@ -1432,6 +1442,8 @@ function resetGame() {
     updateWavePreview();
     elapsedTime = 0;
     lastTime = performance.now();
+    cachedNoiseBuffer = null;
+    cachedNoiseDuration = 0;
 }
 
 function startWave() {
@@ -2840,10 +2852,8 @@ function handlePointerMove(canvasX, canvasY) {
  * @param {boolean} isRightClick - true for secondary action (upgrade), false for primary (build/select)
  */
 function handlePointerDown(canvasX, canvasY, isRightClick) {
+    if (gameOver) return;
     if (isRightClick) {
-        if (gameOver) {
-            return;
-        }
         const tower = getTowerAtPoint(canvasX, canvasY);
         if (!tower) {
             return;
@@ -3152,6 +3162,8 @@ document.addEventListener("keydown", event => {
 let elapsedTime = 0;
 let lastTime = performance.now();
 let rafHandle = 0;
+let loopErrorCount = 0;
+const MAX_LOOP_ERRORS = 10;
 function loop(timestamp) {
     try {
         const rawDt = (timestamp - lastTime) / 1000;
@@ -3163,8 +3175,15 @@ function loop(timestamp) {
             update(scaledDt);
         }
         render();
+        loopErrorCount = 0;
     } catch (e) {
-        console.error('Game loop error:', e.message);
+        console.error('Game loop error:', e);
+        loopErrorCount++;
+        if (loopErrorCount >= MAX_LOOP_ERRORS) {
+            console.error(`Game loop halted after ${MAX_LOOP_ERRORS} consecutive errors.`);
+            announce('게임에 오류가 발생했습니다. 페이지를 새로고침 해주세요.');
+            return;
+        }
     }
     rafHandle = requestAnimationFrame(loop);
 }
@@ -3178,6 +3197,7 @@ function stopLoop() {
 
 function startLoop() {
     stopLoop();
+    loopErrorCount = 0;
     lastTime = performance.now();
     rafHandle = requestAnimationFrame(loop);
 }

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -39,7 +39,10 @@ class FakeAudioContext {
         this.destination = {};
         this.currentTime = 0;
         this.sampleRate = 44100;
+        this.state = 'running';
     }
+    close() { this.state = 'closed'; }
+    resume() { this.state = 'running'; return Promise.resolve(); }
     createGain() { return new FakeGainNode(); }
     createOscillator() { return new FakeOscillator(); }
     createBuffer(channels, length) {
@@ -131,6 +134,21 @@ function run() {
     towerCards[1].click();
     const selectedButtons = Array.from(document.querySelectorAll('.tower-card.selected'));
     assert(selectedButtons.length === 1, 'Selecting a tower card should toggle selected class');
+
+    // #50: setBuildPanelCollapsed가 자식 span을 파괴하지 않는지 검증
+    const buildToggle = document.getElementById('build-toggle');
+    assert(buildToggle, 'build-toggle 버튼이 존재');
+    const arrowBefore = buildToggle.querySelector('.toggle-arrow');
+    const indicatorBefore = document.getElementById('selected-tower-indicator');
+    assert(arrowBefore, 'toggle-arrow span이 초기 상태에서 존재');
+    assert(indicatorBefore, 'selected-tower-indicator span이 초기 상태에서 존재');
+
+    // collapsed 토글 후에도 자식 span이 유지되는지 확인
+    buildToggle.click(); // setBuildPanelCollapsed 호출됨
+    const arrowAfter = buildToggle.querySelector('.toggle-arrow');
+    const indicatorAfter = document.getElementById('selected-tower-indicator');
+    assert(arrowAfter, 'toggle-arrow span이 토글 후에도 유지');
+    assert(indicatorAfter, 'selected-tower-indicator span이 토글 후에도 유지');
 
     console.log('Smoke test passed');
 }

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -39,7 +39,10 @@ class FakeAudioContext {
         this.destination = {};
         this.currentTime = 0;
         this.sampleRate = 44100;
+        this.state = 'running';
     }
+    close() { this.state = 'closed'; }
+    resume() { this.state = 'running'; return Promise.resolve(); }
     createGain() { return new FakeGainNode(); }
     createOscillator() { return new FakeOscillator(); }
     createBuffer(channels, length) {
@@ -338,6 +341,19 @@ function run() {
     const upgMax = upgradeTower(upgTower);
     assertEqual(upgMax, false, 'upgradeTower: 최대 레벨에서 업그레이드 불가');
     assertEqual(upgTower.level, TOWER_MAX_LEVEL, 'upgradeTower: 최대 레벨 유지');
+    towers.length = 0;
+
+    // upgradeTower: gameOver 시 업그레이드 불가
+    enemies.length = 0;
+    towers.length = 0;
+    game.setGold(10000);
+    const upgTowerGO = createTowerData(5, 5, 'basic');
+    towers.push(upgTowerGO);
+    game.setGameOver(true);
+    const upgGameOver = upgradeTower(upgTowerGO);
+    assertEqual(upgGameOver, false, 'upgradeTower: gameOver 상태에서 업그레이드 불가');
+    assertEqual(upgTowerGO.level, 1, 'upgradeTower: gameOver 시 레벨 유지');
+    game.setGameOver(false);
     towers.length = 0;
 
     // --- findTarget ---


### PR DESCRIPTION
## Summary
- #50: BUILD_TOGGLE.textContent → .toggle-arrow span만 변경
- #51: handlePointerDown/upgradeTower에 gameOver 가드 추가
- #52: 게임 루프 에러 카운터 + 연속 에러 시 중단
- #54: AudioContext closed 상태 감지 + 재생성
- #62: CSP unsafe-inline 제거, connect-src/form-action/frame-src 추가

## Test plan
- [x] npm test 통과
- [ ] 브라우저에서 게임 정상 실행 확인

Closes #50, closes #51, closes #52, closes #54, closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)