### PR TITLE
fix: 게임 초기화 시 startLoop() 우회 제거 (#70)

### DIFF
--- a/main.js
+++ b/main.js
@@ -3407,7 +3407,6 @@ if (WAVE_INPUT) {
 
 populateMapList();
 showMapSelectOverlay();
-rafHandle = requestAnimationFrame(loop);
 
 if (typeof module !== 'undefined') {
     module.exports = {


### PR DESCRIPTION
## Summary
- 맵 선택 오버레이 표시 중 `requestAnimationFrame(loop)` 직접 호출을 제거
- `startLoop()` 우회로 인한 3가지 문제 해소:
  - `loopErrorCount` 미초기화
  - `paused=true` 상태에서 불필요한 매 프레임 렌더링
  - `staticLayer` null 상태에서 `drawGrid()`+`drawPath()` 폴백 실행

Closes #70

## 참고
spec-12(dt 클램핑), spec-13(입력 검증), spec-14(오디오 에러 핸들링)은 이전 batch-a에서 이미 구현 완료 확인 → proposal 파일 삭제

## Test plan
- [x] `npm test` 통과 (smoke + unit)
- [ ] 페이지 첫 로드 시 맵 선택 뒤로 빈 격자 안 보이는지 확인
- [ ] 맵 선택 → "시작" 클릭 → 게임 정상 시작
- [ ] Escape 키로 맵 선택 건너뛰기 → 정상 작동
- [ ] 패배 → "다시 시작" → 맵 선택 → "시작" → 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)