### PR TITLE
feat: 키보드 전용 타워 배치/선택 지원 (#42)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 
             <main class="stage-area">
                 <div class="canvas-wrapper">
-                    <canvas id="game" width="900" height="600" role="img" aria-label="타워 디펜스 게임 화면"></canvas>
+                    <canvas id="game" width="900" height="600" tabindex="0" role="application" aria-label="타워 디펜스 게임 화면"></canvas>
                 </div>
             </main>
 

--- a/main.js
+++ b/main.js
@@ -515,6 +515,8 @@ let spawnCooldown = 0;
 let nextWaveTimer = 0;
 let paused = false;
 let hoverTile = null;
+let kbCursor = null;
+let kbCursorActive = false;
 let _longPressTimer = null;
 let _longPressFired = false;
 let _touchStartX = 0;
@@ -2869,7 +2871,40 @@ function drawProjectiles() {
 }
 
 
+function initKbCursor() {
+    kbCursor = { x: Math.floor(GRID_COLS / 2), y: Math.floor(GRID_ROWS / 2) };
+    kbCursorActive = true;
+}
+
+function moveKbCursor(dx, dy) {
+    if (!kbCursor) initKbCursor();
+    kbCursor.x = Math.max(0, Math.min(GRID_COLS - 1, kbCursor.x + dx));
+    kbCursor.y = Math.max(0, Math.min(GRID_ROWS - 1, kbCursor.y + dy));
+    kbCursorActive = true;
+    hoverTile = { x: kbCursor.x, y: kbCursor.y };
+    renderDirty = true;
+}
+
+function activateKbCursor(isUpgrade) {
+    if (!kbCursor) return;
+    const worldX = kbCursor.x * TILE_SIZE + TILE_CENTER_OFFSET;
+    const worldY = kbCursor.y * TILE_SIZE + TILE_CENTER_OFFSET;
+    handlePointerDown(worldX, worldY, isUpgrade);
+}
+
 function drawHover() {
+    if (kbCursorActive && kbCursor) {
+        ctx.save();
+        ctx.strokeStyle = "rgba(255, 220, 100, 0.8)";
+        ctx.lineWidth = 2;
+        ctx.strokeRect(
+            kbCursor.x * TILE_SIZE + 1,
+            kbCursor.y * TILE_SIZE + 1,
+            TILE_SIZE - 2,
+            TILE_SIZE - 2
+        );
+        ctx.restore();
+    }
     if (!hoverTile) {
         return;
     }
@@ -2962,6 +2997,7 @@ function getCanvasCoords(clientX, clientY) {
  */
 const _hoverTileObj = { x: 0, y: 0 };
 function handlePointerMove(canvasX, canvasY) {
+    kbCursorActive = false;
     const tileX = Math.floor(canvasX / TILE_SIZE);
     const tileY = Math.floor(canvasY / TILE_SIZE);
     if (tileX >= 0 && tileX < GRID_COLS && tileY >= 0 && tileY < GRID_ROWS) {
@@ -3041,6 +3077,12 @@ function handlePointerDown(canvasX, canvasY, isRightClick) {
 canvas.addEventListener("mousemove", event => {
     const { x, y } = getCanvasCoords(event.clientX, event.clientY);
     handlePointerMove(x, y);
+});
+
+canvas.addEventListener("focus", () => {
+    if (!kbCursor) initKbCursor();
+    kbCursorActive = true;
+    renderDirty = true;
 });
 
 canvas.addEventListener("mouseleave", () => {
@@ -3334,6 +3376,26 @@ document.addEventListener("keydown", event => {
         }
         return;
     }
+
+    if (!isInput) {
+        switch (event.key) {
+            case 'ArrowUp':    event.preventDefault(); moveKbCursor(0, -1); return;
+            case 'ArrowDown':  event.preventDefault(); moveKbCursor(0, 1); return;
+            case 'ArrowLeft':  event.preventDefault(); moveKbCursor(-1, 0); return;
+            case 'ArrowRight': event.preventDefault(); moveKbCursor(1, 0); return;
+            case 'Enter':      event.preventDefault(); activateKbCursor(event.shiftKey); return;
+            case 's': case 'S':
+                if (selectedTower && !gameOver) sellTower(selectedTower);
+                return;
+            case 'Escape':
+                kbCursorActive = false;
+                kbCursor = null;
+                hoverTile = null;
+                hideAllStats();
+                renderDirty = true;
+                return;
+        }
+    }
 });
 
 let elapsedTime = 0;
@@ -3419,6 +3481,9 @@ if (typeof module !== 'undefined') {
         buildMapData,
         startWave,
         handleLaserAttack,
+        initKbCursor, moveKbCursor, activateKbCursor,
+        getKbCursor: () => kbCursor,
+        getKbCursorActive: () => kbCursorActive,
         getWaypoints: () => waypoints,
         getWave: () => wave,
         getLives: () => lives,


### PR DESCRIPTION
## Summary
- canvas에 `tabindex="0"` + `role="application"` 추가 — 키보드 포커스 가능
- 방향키 그리드 커서 이동 (노란색 테두리, 경계 클램핑)
- Enter: 빌드/선택, Shift+Enter: 업그레이드, S: 판매, Escape: 해제
- 마우스/키보드 모드 자동 전환 (마우스 이동 시 커서 숨김, 방향키 시 복원)
- 66줄 추가 (main.js 65줄 + index.html 1줄 변경)

Closes #42

## Test plan
- [x] `npm test` 통과 (smoke + unit)
- [ ] Tab으로 캔버스 포커스 → 노란색 커서 중앙 표시
- [ ] 방향키로 커서 이동 (경계에서 멈춤)
- [ ] Enter로 타워 건설
- [ ] Shift+Enter로 업그레이드
- [ ] S키로 판매
- [ ] Escape로 커서/선택 해제
- [ ] 마우스 이동 → 키보드 커서 숨김 → 방향키 → 다시 표시
- [ ] 기존 Space(일시정지), U(업그레이드) 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)