### PR TITLE
fix: 버그 수정 배치 A (#89, #90, #95, #96)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1244,7 +1244,7 @@ function damageEnemyAtIndex(index, amount) {
             hideEnemyStats();
         }
         enemies.splice(index, 1);
-        gold += enemy.reward;
+        gold = Math.min(999999, gold + enemy.reward);
         updateGoldUI();
         playSound('kill');
         return true;
@@ -1404,7 +1404,7 @@ function sellTower(tower) {
     const refund = Math.floor((tower.spentGold || 0) * 0.5);
     towers.splice(idx, 1);
     towerPositionSet.delete(keyFromGrid(tower.x, tower.y));
-    gold += refund;
+    gold = Math.min(999999, gold + refund);
     updateGoldUI();
     if (selectedTower === tower) hideTowerStats();
     playSound('build');
@@ -1552,6 +1552,8 @@ function resetGame() {
     elapsedTime = 0;
     lastTime = performance.now();
     cachedNoiseBuffer = null;
+    gameLoopHalted = false;
+    loopErrorCount = 0;
     cachedNoiseDuration = 0;
 }
 
@@ -1891,7 +1893,11 @@ function handleLaserAttack(tower, dt, def) {
         return;
     }
     const target = result.enemy;
-    const targetIndex = result.index;
+    let targetIndex = result.index;
+    if (enemies[targetIndex] !== target) {
+        targetIndex = enemies.indexOf(target);
+        if (targetIndex === -1) { tower.activeBeam = null; return; }
+    }
     const angle = Math.atan2(target.y - tower.worldY, target.x - tower.worldX);
     tower.aimAngle = angle;
     if (typeof tower.heading !== 'number') {
@@ -3274,6 +3280,7 @@ if (RETRY_BUTTON) {
 if (CANCEL_RETRY_BUTTON) {
     CANCEL_RETRY_BUTTON.addEventListener('click', () => {
         hideDefeatDialog();
+        showMapSelectOverlay();
     });
 }
 
@@ -3352,9 +3359,11 @@ if (MAP_SELECT_OVERLAY) {
 document.addEventListener("keydown", event => {
     const tag = event.target ? event.target.tagName : '';
     const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+    const overlayOpen = (DEFEAT_OVERLAY && !DEFEAT_OVERLAY.classList.contains('hidden'))
+        || (MAP_SELECT_OVERLAY && !MAP_SELECT_OVERLAY.classList.contains('hidden'));
 
     if (event.code === "Space") {
-        if (lives === 0 || gameOver) {
+        if (lives === 0 || gameOver || overlayOpen) {
             return;
         }
         paused = !paused;
@@ -3377,7 +3386,7 @@ document.addEventListener("keydown", event => {
         return;
     }
 
-    if (!isInput) {
+    if (!isInput && !overlayOpen) {
         switch (event.key) {
             case 'ArrowUp':    event.preventDefault(); moveKbCursor(0, -1); return;
             case 'ArrowDown':  event.preventDefault(); moveKbCursor(0, 1); return;


### PR DESCRIPTION
## Summary
- **#89** gameLoopHalted 리셋 + cancel 버튼 → 맵 선택으로 전환
- **#90** 오버레이 열린 상태에서 Space/Arrow/Enter 관통 방지
- **#95** gold 999999 상한 클램핑 (kill/sell)
- **#96** 레이저 타워 stale targetIndex 재검증

Closes #89, closes #90, closes #95, closes #96

## Test plan
- [x] npm test 통과
- [ ] 에러 화면 → Retry → 게임 정상 재시작
- [ ] Cancel 버튼 → 맵 선택 오버레이 표시
- [ ] 맵 선택 중 Space/Arrow 미동작
- [ ] 후반 웨이브 gold 999999 초과 안 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)