### PR TITLE
fix: 접근성 배치 B (#91, #92, #97)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,8 @@
 
             <main class="stage-area">
                 <div class="canvas-wrapper">
-                    <canvas id="game" width="900" height="600" tabindex="0" role="application" aria-label="타워 디펜스 게임 화면"></canvas>
+                    <canvas id="game" width="900" height="600" tabindex="0" role="application" aria-label="타워 디펜스 게임 화면" aria-describedby="canvas-keys-desc"></canvas>
+                    <span id="canvas-keys-desc" class="sr-only">방향키: 커서 이동, Enter: 배치/선택, Shift+Enter: 업그레이드, S: 판매, U: 업그레이드, Space: 일시정지, Escape: 해제</span>
                 </div>
             </main>
 

--- a/main.js
+++ b/main.js
@@ -1445,6 +1445,7 @@ function showDefeatDialog() {
         }
     }
     updateWavePreview(0);
+    announce('패배했습니다');
 }
 
 function hideDefeatDialog() {
@@ -1567,6 +1568,7 @@ function startWave() {
         WAVE_INPUT.value = wave;
     }
     updateWavePreview(enemiesToSpawn + enemies.length);
+    announce(`웨이브 ${wave} 시작`);
 }
 
 function canBuildAt(x, y) {
@@ -1958,6 +1960,7 @@ function update(dt) {
         } else if (enemies.length === 0) {
             waveInProgress = false;
             nextWaveTimer = 4;
+            announce(`웨이브 ${wave} 완료`);
             wave = Math.min(wave + 1, WAVE_MAX);
             if (WAVE_LABEL) WAVE_LABEL.textContent = wave;
             if (WAVE_INPUT) {
@@ -2889,6 +2892,8 @@ function moveKbCursor(dx, dy) {
     kbCursorActive = true;
     hoverTile = { x: kbCursor.x, y: kbCursor.y };
     renderDirty = true;
+    const tileInfo = canBuildAt(kbCursor.x, kbCursor.y) ? '빈 타일' : '배치 불가';
+    announce(`${kbCursor.x + 1}, ${kbCursor.y + 1} ${tileInfo}`);
 }
 
 function activateKbCursor(isUpgrade) {
@@ -3088,6 +3093,11 @@ canvas.addEventListener("mousemove", event => {
 canvas.addEventListener("focus", () => {
     if (!kbCursor) initKbCursor();
     kbCursorActive = true;
+    renderDirty = true;
+});
+
+canvas.addEventListener("blur", () => {
+    kbCursorActive = false;
     renderDirty = true;
 });
 

--- a/style.css
+++ b/style.css
@@ -503,6 +503,7 @@ canvas {
 #upgrade-tower-button {
     margin-top: 8px;
     width: 100%;
+    min-height: 44px;
     background: rgba(106, 168, 255, 0.12);
     border: 1px solid rgba(106, 168, 255, 0.4);
     border-radius: 999px;
@@ -528,6 +529,7 @@ canvas {
 #sell-tower-button {
     margin-top: 8px;
     width: 100%;
+    min-height: 44px;
     background: rgba(255, 131, 100, 0.12);
     border: 1px solid rgba(255, 131, 100, 0.4);
     border-radius: 999px;


### PR DESCRIPTION
## Summary
- **#91** moveKbCursor에 announce(타일 위치+상태), canvas blur 핸들러, aria-describedby 단축키 안내
- **#92** startWave/wave-complete/showDefeatDialog에 announce 호출 추가
- **#97** upgrade/sell 버튼 min-height: 44px (WCAG 2.5.5)

Closes #91, closes #92, closes #97

## Test plan
- [x] npm test 통과
- [ ] 방향키 커서 이동 시 스크린 리더 알림 (좌표 + 빈타일/배치불가)
- [ ] Tab out → 노란 커서 사라짐
- [ ] 웨이브 시작/완료/패배 시 알림
- [ ] 버튼 높이 44px 이상

🤖 Generated with [Claude Code](https://claude.com/claude-code)