### PR TITLE
feat: 맵 경로 미리보기 + 맵별 파라미터 + Canvas 컨텍스트 복구 (#107, #119)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -2,7 +2,7 @@ const canvas = document.getElementById('game');
 if (!canvas) {
     throw new Error('Canvas element #game not found');
 }
-const ctx = canvas.getContext('2d');
+let ctx = canvas.getContext('2d');
 if (!ctx) {
     throw new Error('Failed to get 2D rendering context');
 }

--- a/game.js
+++ b/game.js
@@ -304,6 +304,50 @@ function hideMapSelectOverlay() {
     }
 }
 
+function drawMapPreview(previewCtx, rawWaypoints, width, height) {
+    if (!previewCtx || !rawWaypoints || rawWaypoints.length < 2) return;
+    var xs = rawWaypoints.map(function (p) {
+        return p.x;
+    });
+    var ys = rawWaypoints.map(function (p) {
+        return p.y;
+    });
+    var minX = Math.min.apply(null, xs),
+        maxX = Math.max.apply(null, xs);
+    var minY = Math.min.apply(null, ys),
+        maxY = Math.max.apply(null, ys);
+    var rangeX = maxX - minX || 1;
+    var rangeY = maxY - minY || 1;
+    var padding = 10;
+    var scaleX = (width - padding * 2) / rangeX;
+    var scaleY = (height - padding * 2) / rangeY;
+    var scale = Math.min(scaleX, scaleY);
+    var offsetX = (width - rangeX * scale) / 2;
+    var offsetY = (height - rangeY * scale) / 2;
+    previewCtx.strokeStyle = '#6296ff';
+    previewCtx.lineWidth = 3;
+    previewCtx.lineCap = 'round';
+    previewCtx.lineJoin = 'round';
+    previewCtx.beginPath();
+    for (var i = 0; i < rawWaypoints.length; i++) {
+        var px = (rawWaypoints[i].x - minX) * scale + offsetX;
+        var py = (rawWaypoints[i].y - minY) * scale + offsetY;
+        if (i === 0) previewCtx.moveTo(px, py);
+        else previewCtx.lineTo(px, py);
+    }
+    previewCtx.stroke();
+    var start = rawWaypoints[0];
+    var end = rawWaypoints[rawWaypoints.length - 1];
+    previewCtx.fillStyle = '#4caf50';
+    previewCtx.beginPath();
+    previewCtx.arc((start.x - minX) * scale + offsetX, (start.y - minY) * scale + offsetY, 4, 0, Math.PI * 2);
+    previewCtx.fill();
+    previewCtx.fillStyle = '#f44336';
+    previewCtx.beginPath();
+    previewCtx.arc((end.x - minX) * scale + offsetX, (end.y - minY) * scale + offsetY, 4, 0, Math.PI * 2);
+    previewCtx.fill();
+}
+
 function populateMapList() {
     if (!MAP_LIST_CONTAINER) {
         return;
@@ -324,8 +368,20 @@ function populateMapList() {
         diffEl.className = 'map-card-difficulty';
         diffEl.textContent = '난이도: ' + mapDef.difficulty;
 
+        var previewCanvas = document.createElement('canvas');
+        previewCanvas.width = 150;
+        previewCanvas.height = 100;
+        previewCanvas.className = 'map-preview-canvas';
+        previewCanvas.setAttribute('aria-hidden', 'true');
+        var previewCtx = previewCanvas.getContext('2d');
+        drawMapPreview(previewCtx, mapDef.rawWaypoints, 150, 100);
+
+        var paramsEl = document.createElement('span');
+        paramsEl.className = 'map-card-params';
+        paramsEl.textContent = '골드: ' + (mapDef.initialGold || 100) + ' / 생명력: ' + (mapDef.initialLives || 20);
+
         card.setAttribute('aria-pressed', String(mapDef.id === activeMapId));
-        card.append(nameEl, diffEl);
+        card.append(nameEl, previewCanvas, diffEl, paramsEl);
         card.addEventListener('click', () => {
             activeMapId = mapDef.id;
             cards.forEach((c) => {
@@ -342,8 +398,9 @@ function populateMapList() {
 function resetGame() {
     buildMapData(activeMapId);
     staticLayer = null;
-    gold = 100;
-    lives = 20;
+    var currentMapDef = MAP_DEFINITIONS[activeMapId] || MAP_DEFINITIONS['map1'];
+    gold = currentMapDef.initialGold || 100;
+    lives = currentMapDef.initialLives || 20;
     wave = 1;
     gameOver = false;
     paused = false;

--- a/map.js
+++ b/map.js
@@ -3,6 +3,8 @@ const MAP_DEFINITIONS = {
         id: 'map1',
         name: '기본 맵',
         difficulty: '보통',
+        initialGold: 100,
+        initialLives: 20,
         rawWaypoints: [
             { x: -2, y: 8 },
             { x: 2, y: 8 },
@@ -20,6 +22,8 @@ const MAP_DEFINITIONS = {
         id: 'map2',
         name: 'S자 맵',
         difficulty: '어려움',
+        initialGold: 120,
+        initialLives: 15,
         rawWaypoints: [
             { x: -2, y: 3 },
             { x: 8, y: 3 },
@@ -35,6 +39,8 @@ const MAP_DEFINITIONS = {
         id: 'map3',
         name: '나선 맵',
         difficulty: '쉬움',
+        initialGold: 80,
+        initialLives: 25,
         rawWaypoints: [
             { x: -2, y: 10 },
             { x: 4, y: 10 },

--- a/renderer.js
+++ b/renderer.js
@@ -872,9 +872,40 @@ function drawState() {
     ctx.restore();
 }
 
+let contextLostNotified = false;
+
+function tryRecoverContext() {
+    try {
+        ctx = canvas.getContext('2d');
+        if (ctx) {
+            contextLostNotified = false;
+            console.info('Canvas 2D context recovered.');
+            buildStaticLayer();
+            return true;
+        }
+    } catch (e) {
+        console.error('Canvas context recovery failed:', e);
+    }
+    if (!contextLostNotified) {
+        contextLostNotified = true;
+        announce('렌더링 오류가 발생했습니다. 페이지를 새로고침 해주세요.');
+    }
+    return false;
+}
+
 function render() {
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!ctx) {
+        tryRecoverContext();
+        return;
+    }
+    try {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+    } catch (e) {
+        console.error('Canvas context lost during render:', e);
+        ctx = null;
+        tryRecoverContext();
+        return;
+    }
     if (staticLayer) {
         ctx.drawImage(staticLayer, 0, 0);
     } else {

--- a/style.css
+++ b/style.css
@@ -56,7 +56,7 @@ body {
     min-height: 100vh;
     background: var(--bg-gradient);
     color: var(--text-main);
-    font-family: "Noto Sans KR", "Segoe UI", sans-serif;
+    font-family: 'Noto Sans KR', 'Segoe UI', sans-serif;
     display: flex;
     justify-content: center;
     padding: 32px 24px 48px;
@@ -158,7 +158,10 @@ body {
     font-size: 14px;
     min-height: 44px;
     cursor: pointer;
-    transition: transform var(--transition), background var(--transition), border var(--transition);
+    transition:
+        transform var(--transition),
+        background var(--transition),
+        border var(--transition);
 }
 
 .speed-button:hover,
@@ -257,7 +260,9 @@ body {
     display: flex;
     flex-direction: column;
     gap: 12px;
-    transition: transform var(--transition), opacity var(--transition);
+    transition:
+        transform var(--transition),
+        opacity var(--transition);
 }
 
 .build-shell.collapsed .build-panel {
@@ -294,7 +299,10 @@ body {
     border-radius: var(--radius-sm);
     padding: 12px 14px;
     text-align: left;
-    transition: transform var(--transition), border var(--transition), box-shadow var(--transition);
+    transition:
+        transform var(--transition),
+        border var(--transition),
+        box-shadow var(--transition);
 }
 
 .tower-card:hover {
@@ -428,7 +436,7 @@ canvas {
 @media (max-width: 1180px) {
     .app-body {
         grid-template-columns: 280px 1fr;
-        grid-template-areas: "build stage" "info info";
+        grid-template-areas: 'build stage' 'info info';
     }
     .info-column {
         grid-area: info;
@@ -511,7 +519,9 @@ canvas {
     font-size: 14px;
     color: var(--accent);
     cursor: pointer;
-    transition: background var(--transition), border var(--transition);
+    transition:
+        background var(--transition),
+        border var(--transition);
 }
 
 #upgrade-tower-button:hover {
@@ -537,7 +547,9 @@ canvas {
     font-size: 14px;
     color: var(--danger);
     cursor: pointer;
-    transition: background var(--transition), border var(--transition);
+    transition:
+        background var(--transition),
+        border var(--transition);
 }
 
 #sell-tower-button:hover {
@@ -547,9 +559,18 @@ canvas {
 
 /* 골드 부족 피드백 */
 @keyframes gold-flash {
-    0%   { border-color: var(--danger); background: rgba(255, 131, 100, 0.18); }
-    60%  { border-color: rgba(255, 131, 100, 0.7); background: rgba(255, 131, 100, 0.22); }
-    100% { border-color: rgba(255, 255, 255, 0.08); background: rgba(255, 255, 255, 0.04); }
+    0% {
+        border-color: var(--danger);
+        background: rgba(255, 131, 100, 0.18);
+    }
+    60% {
+        border-color: rgba(255, 131, 100, 0.7);
+        background: rgba(255, 131, 100, 0.22);
+    }
+    100% {
+        border-color: rgba(255, 255, 255, 0.08);
+        background: rgba(255, 255, 255, 0.04);
+    }
 }
 
 .stat-chip.flash-insufficient {
@@ -603,7 +624,11 @@ canvas {
     text-align: left;
     color: var(--text-main);
     width: 100%;
-    transition: transform var(--transition), border var(--transition), box-shadow var(--transition), background var(--transition);
+    transition:
+        transform var(--transition),
+        border var(--transition),
+        box-shadow var(--transition),
+        background var(--transition);
 }
 
 .map-card:hover {
@@ -616,7 +641,9 @@ canvas {
 .map-card.selected {
     background: rgba(106, 168, 255, 0.12);
     border-color: var(--accent);
-    box-shadow: 0 0 0 2px var(--accent-soft), 0 14px 24px rgba(19, 58, 110, 0.45);
+    box-shadow:
+        0 0 0 2px var(--accent-soft),
+        0 14px 24px rgba(19, 58, 110, 0.45);
 }
 
 .map-card-name {
@@ -629,6 +656,23 @@ canvas {
     color: var(--text-muted);
 }
 
+.map-preview-canvas {
+    display: block;
+    width: 100%;
+    max-width: 150px;
+    height: auto;
+    margin: 6px auto;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.map-card-params {
+    display: block;
+    font-size: 0.85em;
+    color: #b0b8c8;
+    margin-top: 4px;
+}
+
 .restart-button {
     margin-top: 6px;
     background: var(--accent);
@@ -639,7 +683,10 @@ canvas {
     font-weight: 600;
     color: #071432;
     cursor: pointer;
-    transition: background var(--transition), border var(--transition), transform var(--transition);
+    transition:
+        background var(--transition),
+        border var(--transition),
+        transform var(--transition);
 }
 
 .restart-button:hover {
@@ -755,7 +802,9 @@ canvas {
 
 /* ── Reduced motion preference ── */
 @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
+    *,
+    *::before,
+    *::after {
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary
- #107: 맵 선택 화면에 경로 미리보기 캔버스 + 맵별 초기 골드/생명력 파라미터 차별화
- #119: Canvas 컨텍스트 유실 감지 및 복구 메커니즘 (tryRecoverContext)

## Test plan
- [x] npm test 53/53 통과
- [ ] 맵 선택 화면에서 3개 맵의 경로 미리보기 확인
- [ ] S자 맵 선택 시 골드 120, 생명력 15로 시작 확인

Closes #107, closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)