### PR TITLE
feat: 타워별 타겟 우선순위 선택 기능

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -93,6 +93,14 @@ ENEMY_TYPE_DEFINITIONS.forEach((t) => {
     ENEMY_TYPE_MAP[t.id] = t;
 });
 
+const TARGET_PRIORITIES = [
+    { key: 'first', label: '선두' },
+    { key: 'last', label: '후미' },
+    { key: 'strongest', label: '강한 적' },
+    { key: 'weakest', label: '약한 적' },
+    { key: 'closest', label: '가까운 적' }
+];
+
 const gameState = {
     gold: 100,
     lives: 20,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ const gameGlobals = {
     prefersReducedMotion: 'writable',
     ENEMY_TYPE_DEFINITIONS: 'readonly',
     ENEMY_TYPE_MAP: 'readonly',
+    TARGET_PRIORITIES: 'readonly',
     gameState: 'readonly',
 
     // towers.js
@@ -105,6 +106,7 @@ const gameGlobals = {
     SELECTED_TOWER_INDICATOR: 'readonly',
     UPGRADE_TOWER_BUTTON: 'readonly',
     SELL_TOWER_BUTTON: 'readonly',
+    TARGET_PRIORITY_SELECT: 'readonly',
     announceQueue: 'readonly',
     announceProcessing: 'writable',
     processAnnounceQueue: 'readonly',

--- a/game.js
+++ b/game.js
@@ -478,7 +478,8 @@ function createTowerData(x, y, typeId) {
         flashTimer: 0,
         recoil: 0,
         auraOffset: Math.random() * Math.PI * 2,
-        spentGold: def.cost || 0
+        spentGold: def.cost || 0,
+        targetPriority: 'first'
     };
 }
 
@@ -518,13 +519,31 @@ function findTarget(tower) {
     let chosenIndex = -1;
     let bestScore = -Infinity;
     const rangeSq = tower.range * tower.range;
+    const priority = tower.targetPriority || 'first';
     for (let i = 0; i < enemies.length; i++) {
         const enemy = enemies[i];
         const dx = enemy.x - tower.worldX;
         const dy = enemy.y - tower.worldY;
         const distSq = dx * dx + dy * dy;
         if (distSq > rangeSq) continue;
-        const score = enemy.waypoint * 1000 - distSq;
+        let score;
+        switch (priority) {
+            case 'last':
+                score = -(enemy.waypoint * 1000 - distSq);
+                break;
+            case 'strongest':
+                score = enemy.hp;
+                break;
+            case 'weakest':
+                score = -enemy.hp;
+                break;
+            case 'closest':
+                score = -distSq;
+                break;
+            default:
+                score = enemy.waypoint * 1000 - distSq;
+                break;
+        }
         if (score > bestScore) {
             bestScore = score;
             chosen = enemy;

--- a/index.html
+++ b/index.html
@@ -1,144 +1,183 @@
-﻿<!DOCTYPE html>
+﻿<!doctype html>
 <html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- NOTE: 서버 배포 시 HTTP 헤더로 CSP 전환 권장 (frame-ancestors 'none' 추가 가능) -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'self'; connect-src 'none'; form-action 'none'; frame-src 'none';">
-    <title>타워 디펜스 커맨드</title>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
-    <div class="app-shell">
-        <header class="top-bar">
-            <div class="bar-left">
-                <h1 class="brand">타워 디펜스 커맨드</h1>
-                <div class="stat-block">
-                    <div class="stat-chip" aria-live="polite" aria-atomic="true">
-                        <span class="stat-label">웨이브</span>
-                        <span class="stat-value" id="wave">1</span>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!-- NOTE: 서버 배포 시 HTTP 헤더로 CSP 전환 권장 (frame-ancestors 'none' 추가 가능) -->
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'self'; connect-src 'none'; form-action 'none'; frame-src 'none';"
+        />
+        <title>타워 디펜스 커맨드</title>
+        <link rel="stylesheet" href="style.css" />
+    </head>
+    <body>
+        <div class="app-shell">
+            <header class="top-bar">
+                <div class="bar-left">
+                    <h1 class="brand">타워 디펜스 커맨드</h1>
+                    <div class="stat-block">
+                        <div class="stat-chip" aria-live="polite" aria-atomic="true">
+                            <span class="stat-label">웨이브</span>
+                            <span class="stat-value" id="wave">1</span>
+                        </div>
+                        <div class="stat-chip" aria-live="polite" aria-atomic="true">
+                            <span class="stat-label">생명력</span>
+                            <span class="stat-value" id="lives">20</span>
+                        </div>
+                        <div class="stat-chip">
+                            <span class="stat-label">골드</span>
+                            <span class="stat-value" id="gold">100</span>
+                        </div>
                     </div>
-                    <div class="stat-chip" aria-live="polite" aria-atomic="true">
-                        <span class="stat-label">생명력</span>
-                        <span class="stat-value" id="lives">20</span>
+                </div>
+                <div class="bar-right">
+                    <div class="control-row speed-controls" role="group" aria-label="게임 속도">
+                        <span class="control-label">속도</span>
+                        <button type="button" class="speed-button active" data-speed="1">1x</button>
+                        <button type="button" class="speed-button" data-speed="2">2x</button>
+                        <button type="button" class="speed-button" data-speed="3">3x</button>
                     </div>
-                    <div class="stat-chip">
-                        <span class="stat-label">골드</span>
-                        <span class="stat-value" id="gold">100</span>
+                    <div class="control-row gold-control">
+                        <label for="gold-input" class="control-label">골드</label>
+                        <input type="number" id="gold-input" min="0" max="999999" step="10" value="100" />
+                        <button type="button" id="gold-apply">설정</button>
+                        <button type="button" class="gold-adjust" data-delta="100">+100</button>
+                        <button type="button" class="gold-adjust" data-delta="500">+500</button>
+                    </div>
+                    <div class="control-row wave-control">
+                        <label for="wave-input" class="control-label">웨이브 이동</label>
+                        <input type="number" id="wave-input" min="1" max="9999" value="1" />
+                        <button type="button" id="wave-apply">이동</button>
+                    </div>
+                    <div class="control-row sound-control">
+                        <button
+                            type="button"
+                            id="sound-toggle"
+                            class="icon-button"
+                            aria-pressed="true"
+                            aria-label="사운드 끄기"
+                            title="사운드 끄기"
+                        >
+                            🔊
+                        </button>
                     </div>
                 </div>
-            </div>
-            <div class="bar-right">
-                <div class="control-row speed-controls" role="group" aria-label="게임 속도">
-                    <span class="control-label">속도</span>
-                    <button type="button" class="speed-button active" data-speed="1">1x</button>
-                    <button type="button" class="speed-button" data-speed="2">2x</button>
-                    <button type="button" class="speed-button" data-speed="3">3x</button>
-                </div>
-                <div class="control-row gold-control">
-                    <label for="gold-input" class="control-label">골드</label>
-                    <input type="number" id="gold-input" min="0" max="999999" step="10" value="100">
-                    <button type="button" id="gold-apply">설정</button>
-                    <button type="button" class="gold-adjust" data-delta="100">+100</button>
-                    <button type="button" class="gold-adjust" data-delta="500">+500</button>
-                </div>
-                <div class="control-row wave-control">
-                    <label for="wave-input" class="control-label">웨이브 이동</label>
-                    <input type="number" id="wave-input" min="1" max="9999" value="1">
-                    <button type="button" id="wave-apply">이동</button>
-                </div>
-                <div class="control-row sound-control">
-                    <button type="button" id="sound-toggle" class="icon-button" aria-pressed="true" aria-label="사운드 끄기" title="사운드 끄기">🔊</button>
-                </div>
-            </div>
-        </header>
+            </header>
 
-        <p class="instructions">왼쪽 패널을 펼친 뒤 원하는 포탑을 선택하고 캔버스를 좌클릭하면 설치됩니다. 우클릭 업그레이드는 최대 레벨 15까지 가능하며 각 포탑은 고유한 사거리·피해·효과(지속/광역/산탄/박격포)를 가집니다. 골드와 웨이브는 상단 HUD에서 즉시 조정할 수 있고, 사운드 토글로 효과음을 켜거나 끌 수 있습니다.</p>
+            <p class="instructions">
+                왼쪽 패널을 펼친 뒤 원하는 포탑을 선택하고 캔버스를 좌클릭하면 설치됩니다. 우클릭 업그레이드는 최대 레벨
+                15까지 가능하며 각 포탑은 고유한 사거리·피해·효과(지속/광역/산탄/박격포)를 가집니다. 골드와 웨이브는
+                상단 HUD에서 즉시 조정할 수 있고, 사운드 토글로 효과음을 켜거나 끌 수 있습니다.
+            </p>
 
-        <div class="app-body">
-            <div class="build-shell">
-                <button type="button" id="build-toggle" class="build-toggle" aria-expanded="true" aria-controls="build-panel" aria-label="포탑 패널 접기" title="포탑 패널 접기">
-                    <span class="toggle-arrow">◀</span>
-                    <span id="selected-tower-indicator" class="selected-tower-indicator"></span>
-                </button>
-                <aside id="build-panel" class="build-panel">
-                    <h2>포탑 제작</h2>
-                    <p class="build-hint">왼쪽에서 포탑을 선택한 뒤 지형을 클릭하세요.</p>
-                    <div id="tower-list" class="tower-list" role="radiogroup" aria-label="포탑 선택"></div>
+            <div class="app-body">
+                <div class="build-shell">
+                    <button
+                        type="button"
+                        id="build-toggle"
+                        class="build-toggle"
+                        aria-expanded="true"
+                        aria-controls="build-panel"
+                        aria-label="포탑 패널 접기"
+                        title="포탑 패널 접기"
+                    >
+                        <span class="toggle-arrow">◀</span>
+                        <span id="selected-tower-indicator" class="selected-tower-indicator"></span>
+                    </button>
+                    <aside id="build-panel" class="build-panel">
+                        <h2>포탑 제작</h2>
+                        <p class="build-hint">왼쪽에서 포탑을 선택한 뒤 지형을 클릭하세요.</p>
+                        <div id="tower-list" class="tower-list" role="radiogroup" aria-label="포탑 선택"></div>
+                    </aside>
+                </div>
+
+                <main class="stage-area">
+                    <div class="canvas-wrapper">
+                        <canvas
+                            id="game"
+                            width="900"
+                            height="600"
+                            tabindex="0"
+                            role="application"
+                            aria-label="타워 디펜스 게임 화면"
+                            aria-describedby="canvas-keys-desc"
+                        ></canvas>
+                        <span id="canvas-keys-desc" class="sr-only"
+                            >방향키: 커서 이동, Enter: 배치/선택, Shift+Enter: 업그레이드, S: 판매, U: 업그레이드,
+                            Space: 일시정지, Escape: 해제</span
+                        >
+                    </div>
+                </main>
+
+                <aside class="info-column">
+                    <div id="wave-preview" class="stats-panel card" aria-live="polite" aria-atomic="true">
+                        <h3>다음 웨이브 정보</h3>
+                        <p>상태: <span data-field="preview-status">대기</span></p>
+                        <p>웨이브: <span data-field="preview-wave">1</span></p>
+                        <p>남은 적: <span data-field="preview-remaining">0</span></p>
+                        <p>체력: <span data-field="preview-hp">-</span></p>
+                        <p>이동 속도: <span data-field="preview-speed">-</span></p>
+                        <p>획득 골드: <span data-field="preview-reward">-</span></p>
+                    </div>
+                    <div id="tower-stats" class="stats-panel card hidden">
+                        <h3>포탑 정보</h3>
+                        <p>종류: <span data-field="tower-type">-</span></p>
+                        <p>좌표: <span data-field="tower-position">-</span></p>
+                        <p>사거리: <span data-field="tower-range">-</span></p>
+                        <p>발사 간격: <span data-field="tower-fire-delay">-</span></p>
+                        <p>피해량: <span data-field="tower-damage">-</span></p>
+                        <p>레벨: <span data-field="tower-level">-</span></p>
+                        <p>업그레이드 비용: <span data-field="tower-upgrade-cost">-</span></p>
+                        <p>판매 환급: <span data-field="tower-sell-refund">-</span></p>
+                        <p>
+                            타겟:
+                            <select id="target-priority-select" aria-label="타겟 우선순위"></select>
+                        </p>
+                        <button type="button" id="upgrade-tower-button">업그레이드</button>
+                        <button type="button" id="sell-tower-button">판매</button>
+                    </div>
+                    <div id="enemy-stats" class="stats-panel card hidden">
+                        <h3>적 정보</h3>
+                        <p>종류: <span data-field="enemy-type">-</span></p>
+                        <p>웨이브: <span data-field="enemy-wave">-</span></p>
+                        <p>체력: <span data-field="enemy-hp">-</span></p>
+                        <p>이동 속도: <span data-field="enemy-speed">-</span></p>
+                        <p>획득 골드: <span data-field="enemy-reward">-</span></p>
+                    </div>
                 </aside>
             </div>
-
-            <main class="stage-area">
-                <div class="canvas-wrapper">
-                    <canvas id="game" width="900" height="600" tabindex="0" role="application" aria-label="타워 디펜스 게임 화면" aria-describedby="canvas-keys-desc"></canvas>
-                    <span id="canvas-keys-desc" class="sr-only">방향키: 커서 이동, Enter: 배치/선택, Shift+Enter: 업그레이드, S: 판매, U: 업그레이드, Space: 일시정지, Escape: 해제</span>
-                </div>
-            </main>
-
-            <aside class="info-column">
-                <div id="wave-preview" class="stats-panel card" aria-live="polite" aria-atomic="true">
-                    <h3>다음 웨이브 정보</h3>
-                    <p>상태: <span data-field="preview-status">대기</span></p>
-                    <p>웨이브: <span data-field="preview-wave">1</span></p>
-                    <p>남은 적: <span data-field="preview-remaining">0</span></p>
-                    <p>체력: <span data-field="preview-hp">-</span></p>
-                    <p>이동 속도: <span data-field="preview-speed">-</span></p>
-                    <p>획득 골드: <span data-field="preview-reward">-</span></p>
-                </div>
-                <div id="tower-stats" class="stats-panel card hidden">
-                    <h3>포탑 정보</h3>
-                    <p>종류: <span data-field="tower-type">-</span></p>
-                    <p>좌표: <span data-field="tower-position">-</span></p>
-                    <p>사거리: <span data-field="tower-range">-</span></p>
-                    <p>발사 간격: <span data-field="tower-fire-delay">-</span></p>
-                    <p>피해량: <span data-field="tower-damage">-</span></p>
-                    <p>레벨: <span data-field="tower-level">-</span></p>
-                    <p>업그레이드 비용: <span data-field="tower-upgrade-cost">-</span></p>
-                    <p>판매 환급: <span data-field="tower-sell-refund">-</span></p>
-                    <button type="button" id="upgrade-tower-button">업그레이드</button>
-                    <button type="button" id="sell-tower-button">판매</button>
-                </div>
-                <div id="enemy-stats" class="stats-panel card hidden">
-                    <h3>적 정보</h3>
-                    <p>종류: <span data-field="enemy-type">-</span></p>
-                    <p>웨이브: <span data-field="enemy-wave">-</span></p>
-                    <p>체력: <span data-field="enemy-hp">-</span></p>
-                    <p>이동 속도: <span data-field="enemy-speed">-</span></p>
-                    <p>획득 골드: <span data-field="enemy-reward">-</span></p>
-                </div>
-            </aside>
         </div>
-    </div>
 
-    <div id="map-select-overlay" class="overlay" role="dialog" aria-modal="true" aria-label="맵 선택">
-        <div class="overlay-content">
-            <h2>맵 선택</h2>
-            <div id="map-list"></div>
-            <button type="button" id="start-game-button" class="restart-button">시작</button>
-        </div>
-    </div>
-
-    <div id="defeat-overlay" class="overlay hidden" role="dialog" aria-modal="true" aria-label="패배">
-        <div class="overlay-content">
-            <h2>패배했습니다</h2>
-            <p>다시 시도하시겠습니까?</p>
-            <div class="overlay-actions">
-                <button type="button" id="retry-button">다시 시작</button>
-                <button type="button" id="cancel-retry-button">닫기</button>
+        <div id="map-select-overlay" class="overlay" role="dialog" aria-modal="true" aria-label="맵 선택">
+            <div class="overlay-content">
+                <h2>맵 선택</h2>
+                <div id="map-list"></div>
+                <button type="button" id="start-game-button" class="restart-button">시작</button>
             </div>
         </div>
-    </div>
 
-    <div id="a11y-announcer" class="sr-only" aria-live="assertive" aria-atomic="true"></div>
+        <div id="defeat-overlay" class="overlay hidden" role="dialog" aria-modal="true" aria-label="패배">
+            <div class="overlay-content">
+                <h2>패배했습니다</h2>
+                <p>다시 시도하시겠습니까?</p>
+                <div class="overlay-actions">
+                    <button type="button" id="retry-button">다시 시작</button>
+                    <button type="button" id="cancel-retry-button">닫기</button>
+                </div>
+            </div>
+        </div>
 
-    <script src="constants.js"></script>
-    <script src="towers.js"></script>
-    <script src="utils.js"></script>
-    <script src="map.js"></script>
-    <script src="ui.js"></script>
-    <script src="audio.js"></script>
-    <script src="game.js"></script>
-    <script src="renderer.js"></script>
-    <script src="main.js"></script>
-</body>
+        <div id="a11y-announcer" class="sr-only" aria-live="assertive" aria-atomic="true"></div>
+
+        <script src="constants.js"></script>
+        <script src="towers.js"></script>
+        <script src="utils.js"></script>
+        <script src="map.js"></script>
+        <script src="ui.js"></script>
+        <script src="audio.js"></script>
+        <script src="game.js"></script>
+        <script src="renderer.js"></script>
+        <script src="main.js"></script>
+    </body>
 </html>

--- a/ui.js
+++ b/ui.js
@@ -73,6 +73,21 @@ const A11Y_ANNOUNCER = document.getElementById('a11y-announcer');
 const SELECTED_TOWER_INDICATOR = document.getElementById('selected-tower-indicator');
 const UPGRADE_TOWER_BUTTON = document.getElementById('upgrade-tower-button');
 const SELL_TOWER_BUTTON = document.getElementById('sell-tower-button');
+const TARGET_PRIORITY_SELECT = document.getElementById('target-priority-select');
+
+if (TARGET_PRIORITY_SELECT) {
+    TARGET_PRIORITIES.forEach((p) => {
+        const option = document.createElement('option');
+        option.value = p.key;
+        option.textContent = p.label;
+        TARGET_PRIORITY_SELECT.appendChild(option);
+    });
+    TARGET_PRIORITY_SELECT.addEventListener('change', () => {
+        if (gameState.selectedTower) {
+            gameState.selectedTower.targetPriority = TARGET_PRIORITY_SELECT.value;
+        }
+    });
+}
 
 const announceQueue = [];
 let announceProcessing = false;
@@ -360,6 +375,12 @@ function updateTowerStatsFields() {
     if (SELL_TOWER_BUTTON) {
         const refund = Math.floor((gameState.selectedTower.spentGold || 0) * 0.5);
         SELL_TOWER_BUTTON.setAttribute('aria-label', `판매 (${refund}G 환급)`);
+    }
+    if (TARGET_PRIORITY_SELECT) {
+        const currentPriority = gameState.selectedTower.targetPriority || 'first';
+        if (TARGET_PRIORITY_SELECT.value !== currentPriority) {
+            TARGET_PRIORITY_SELECT.value = currentPriority;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- 각 타워가 독립적으로 타겟 우선순위를 선택할 수 있는 기능 추가
- 5가지 우선순위 지원: 선두(first), 후미(last), 강한 적(strongest), 약한 적(weakest), 가까운 적(closest)
- 포탑 정보 패널에 드롭다운 셀렉트 UI 추가, 타워별 설정이 독립적으로 유지됨

## Changes
- **constants.js**: `TARGET_PRIORITIES` 상수 배열 추가
- **game.js**: `createTowerData()`에 `targetPriority: 'first'` 기본값 추가, `findTarget()`에 우선순위별 스코어링 로직 구현 (switch문)
- **index.html**: `#tower-stats` 패널에 `<select id="target-priority-select">` 추가
- **ui.js**: select 옵션 동적 생성, change 이벤트 핸들러, `updateTowerStatsFields()`에서 현재 우선순위 동기화
- **eslint.config.mjs**: `TARGET_PRIORITIES`, `TARGET_PRIORITY_SELECT` 전역 변수 등록

## Test plan
- [x] `npm test` — 53 tests pass
- [x] `npx eslint *.js tests/` — 0 errors
- [x] `npx prettier --write` — all files formatted
- [ ] 타워 설치 후 포탑 정보 패널에서 타겟 우선순위 드롭다운이 표시되는지 확인
- [ ] 우선순위 변경 시 해당 타워의 타겟팅 동작이 변경되는지 확인
- [ ] 서로 다른 타워에 서로 다른 우선순위를 설정할 수 있는지 확인
- [ ] 타워 선택 시 해당 타워의 현재 우선순위가 드롭다운에 정확히 반영되는지 확인

closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)