### PR TITLE
enhancement: 웨이브 프리뷰 개선 (#108)

### DIFF
--- a/game.js
+++ b/game.js
@@ -495,6 +495,18 @@ function pickEnemyType(waveNumber) {
     return ENEMY_TYPE_DEFINITIONS[0];
 }
 
+function getWaveEnemyComposition(waveNumber) {
+    if (waveNumber < 3) {
+        return [{ type: ENEMY_TYPE_DEFINITIONS[0], percent: 100 }];
+    }
+    const result = [
+        { type: ENEMY_TYPE_MAP['normal'] || ENEMY_TYPE_DEFINITIONS[0], percent: 50 },
+        { type: ENEMY_TYPE_MAP['armored'] || ENEMY_TYPE_DEFINITIONS[0], percent: 20 },
+        { type: ENEMY_TYPE_MAP['fast'] || ENEMY_TYPE_DEFINITIONS[0], percent: 30 }
+    ];
+    return result;
+}
+
 function spawnEnemy() {
     const start = waypoints[0];
     const enemyType = pickEnemyType(gameState.wave);

--- a/index.html
+++ b/index.html
@@ -114,7 +114,9 @@
                     <div id="wave-preview" class="stats-panel card" aria-live="polite" aria-atomic="true">
                         <h3>다음 웨이브 정보</h3>
                         <p>상태: <span data-field="preview-status">대기</span></p>
+                        <p>카운트다운: <span data-field="preview-countdown">-</span></p>
                         <p>웨이브: <span data-field="preview-wave">1</span></p>
+                        <p>적 구성: <span data-field="preview-composition">-</span></p>
                         <p>남은 적: <span data-field="preview-remaining">0</span></p>
                         <p>체력: <span data-field="preview-hp">-</span></p>
                         <p>이동 속도: <span data-field="preview-speed">-</span></p>

--- a/main.js
+++ b/main.js
@@ -555,6 +555,7 @@ if (typeof module !== 'undefined') {
         damageEnemy,
         damageEnemyAtIndex,
         pickEnemyType,
+        getWaveEnemyComposition,
         pathTiles,
         ENEMY_TYPE_DEFINITIONS,
         ENEMY_TYPE_MAP,

--- a/ui.js
+++ b/ui.js
@@ -50,7 +50,9 @@ const WAVE_PREVIEW_PANEL = document.getElementById('wave-preview');
 const WAVE_PREVIEW_FIELDS = WAVE_PREVIEW_PANEL
     ? {
           status: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-status"]'),
+          countdown: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-countdown"]'),
           wave: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-wave"]'),
+          composition: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-composition"]'),
           remaining: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-remaining"]'),
           hp: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-hp"]'),
           speed: WAVE_PREVIEW_PANEL.querySelector('[data-field="preview-speed"]'),
@@ -304,7 +306,25 @@ function updateWavePreview(remainingOverride) {
         status = '대기';
     }
     setTextIfChanged(WAVE_PREVIEW_FIELDS.status, status);
+
+    if (WAVE_PREVIEW_FIELDS.countdown) {
+        let countdownText;
+        if (gameState.nextWaveTimer > 0 && !gameState.waveInProgress && !gameState.gameOver) {
+            countdownText = Math.ceil(gameState.nextWaveTimer) + '초';
+        } else {
+            countdownText = '-';
+        }
+        setTextIfChanged(WAVE_PREVIEW_FIELDS.countdown, countdownText);
+    }
+
     setTextIfChanged(WAVE_PREVIEW_FIELDS.wave, '' + gameState.wave);
+
+    if (WAVE_PREVIEW_FIELDS.composition) {
+        const composition = getWaveEnemyComposition(gameState.wave);
+        const compositionText = composition.map((c) => c.type.label + ' ' + c.percent + '%').join(' / ');
+        setTextIfChanged(WAVE_PREVIEW_FIELDS.composition, compositionText);
+    }
+
     setTextIfChanged(WAVE_PREVIEW_FIELDS.remaining, '' + remaining);
     setTextIfChanged(WAVE_PREVIEW_FIELDS.hp, '' + stats.hp);
     setTextIfChanged(WAVE_PREVIEW_FIELDS.speed, `${(stats.speed / TILE_SIZE).toFixed(2)} 타일/초`);


### PR DESCRIPTION
## Summary
- 웨이브 휴식 중 카운트다운 타이머(초)를 프리뷰 패널에 표시
- 웨이브 3 이상에서 혼합 적 구성 비율(일반 50% / 장갑 20% / 고속 30%)을 프리뷰 패널에 표시
- `getWaveEnemyComposition()` 함수를 `game.js`에 추가하여 웨이브별 적 구성 확률 제공

## Test plan
- [x] `npm test` 전체 53개 테스트 통과
- [x] `npx eslint` 오류 0건 (기존 경고만 존재)
- [x] `npx prettier --write` 변경 없음 (이미 포맷 완료)
- [ ] 웨이브 클리어 후 휴식 상태에서 카운트다운이 4초부터 감소하는지 확인
- [ ] 웨이브 1-2에서 적 구성이 "일반 100%"로 표시되는지 확인
- [ ] 웨이브 3 이상에서 적 구성이 "일반 50% / 장갑 20% / 고속 30%"로 표시되는지 확인
- [ ] 전투 중/대기/패배 상태에서 카운트다운이 "-"로 표시되는지 확인

closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)