### PR TITLE
refactor: 매직넘버 데이터화 (#115)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -26,6 +26,7 @@ const TOWER_UPGRADE_COST_MULTIPLIER = 1.6;
 const TOWER_MAX_LEVEL = 15;
 const WAVE_CLEAR_BONUS_BASE = 20;
 const WAVE_CLEAR_BONUS_PER_WAVE = 5;
+const TOWER_SELL_REFUND_RATE = 0.5;
 const WAVE_MAX = 9999;
 const DEFAULT_TOWER_TYPE = 'basic';
 const AUTOCOLLAPSE_WIDTH = 1180;
@@ -46,6 +47,9 @@ const ENEMY_TYPE_DEFINITIONS = [
         hpMult: 1.0,
         speedMult: 1.0,
         rewardMult: 1.0,
+        spawnWeight: 50,
+        minWave: 1,
+        bossOnly: false,
         body: '#d65a57',
         core: '#ffe6c2',
         outline: '#321816',
@@ -58,6 +62,9 @@ const ENEMY_TYPE_DEFINITIONS = [
         hpMult: 3.0,
         speedMult: 0.6,
         rewardMult: 2.0,
+        spawnWeight: 20,
+        minWave: 3,
+        bossOnly: false,
         body: '#5d7dff',
         core: '#d8e1ff',
         outline: '#19224f',
@@ -70,6 +77,9 @@ const ENEMY_TYPE_DEFINITIONS = [
         hpMult: 0.4,
         speedMult: 2.5,
         rewardMult: 1.5,
+        spawnWeight: 30,
+        minWave: 3,
+        bossOnly: false,
         body: '#58d6a4',
         core: '#d4ffe7',
         outline: '#12392a',
@@ -82,6 +92,9 @@ const ENEMY_TYPE_DEFINITIONS = [
         hpMult: 12.0,
         speedMult: 0.7,
         rewardMult: 8.0,
+        spawnWeight: 0,
+        minWave: 1,
+        bossOnly: true,
         body: '#c95de9',
         core: '#f5d1ff',
         outline: '#3d1649',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,7 @@ const gameGlobals = {
     TOWER_MAX_LEVEL: 'readonly',
     WAVE_CLEAR_BONUS_BASE: 'readonly',
     WAVE_CLEAR_BONUS_PER_WAVE: 'readonly',
+    TOWER_SELL_REFUND_RATE: 'readonly',
     WAVE_MAX: 'readonly',
     DEFAULT_TOWER_TYPE: 'readonly',
     AUTOCOLLAPSE_WIDTH: 'readonly',

--- a/game.js
+++ b/game.js
@@ -218,7 +218,7 @@ function sellTower(tower) {
     if (gameState.gameOver) return false;
     const idx = towers.indexOf(tower);
     if (idx === -1) return false;
-    const refund = Math.floor((tower.spentGold || 0) * 0.5);
+    const refund = Math.floor((tower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
     towers.splice(idx, 1);
     towerPositionSet.delete(keyFromGrid(tower.x, tower.y));
     gameState.gold = Math.min(999999, gameState.gold + refund);
@@ -487,24 +487,25 @@ function pickEnemyType(waveNumber) {
     if (waveNumber % 10 === 0 && gameState.enemiesToSpawn === 1) {
         return ENEMY_TYPE_MAP['boss'] || ENEMY_TYPE_DEFINITIONS[0];
     }
-    if (waveNumber >= 3) {
-        const roll = Math.random();
-        if (roll < 0.2) return ENEMY_TYPE_MAP['armored'] || ENEMY_TYPE_DEFINITIONS[0];
-        if (roll < 0.5) return ENEMY_TYPE_MAP['fast'] || ENEMY_TYPE_DEFINITIONS[0];
+    const eligible = ENEMY_TYPE_DEFINITIONS.filter((t) => !t.bossOnly && waveNumber >= t.minWave);
+    const totalWeight = eligible.reduce((sum, t) => sum + t.spawnWeight, 0);
+    if (totalWeight <= 0) return ENEMY_TYPE_DEFINITIONS[0];
+    let roll = Math.random() * totalWeight;
+    for (const t of eligible) {
+        roll -= t.spawnWeight;
+        if (roll <= 0) return t;
     }
-    return ENEMY_TYPE_DEFINITIONS[0];
+    return eligible[eligible.length - 1];
 }
 
 function getWaveEnemyComposition(waveNumber) {
-    if (waveNumber < 3) {
-        return [{ type: ENEMY_TYPE_DEFINITIONS[0], percent: 100 }];
-    }
-    const result = [
-        { type: ENEMY_TYPE_MAP['normal'] || ENEMY_TYPE_DEFINITIONS[0], percent: 50 },
-        { type: ENEMY_TYPE_MAP['armored'] || ENEMY_TYPE_DEFINITIONS[0], percent: 20 },
-        { type: ENEMY_TYPE_MAP['fast'] || ENEMY_TYPE_DEFINITIONS[0], percent: 30 }
-    ];
-    return result;
+    const eligible = ENEMY_TYPE_DEFINITIONS.filter((t) => !t.bossOnly && waveNumber >= t.minWave);
+    const totalWeight = eligible.reduce((sum, t) => sum + t.spawnWeight, 0);
+    if (totalWeight <= 0) return [{ type: ENEMY_TYPE_DEFINITIONS[0], percent: 100 }];
+    return eligible.map((t) => ({
+        type: t,
+        percent: Math.round((t.spawnWeight / totalWeight) * 100)
+    }));
 }
 
 function spawnEnemy() {

--- a/ui.js
+++ b/ui.js
@@ -389,11 +389,11 @@ function updateTowerStatsFields() {
         UPGRADE_TOWER_BUTTON.setAttribute('aria-label', label);
     }
     if (TOWER_STATS_FIELDS.sellRefund) {
-        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * 0.5);
+        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
         setTextIfChanged(TOWER_STATS_FIELDS.sellRefund, formatNumber(refund));
     }
     if (SELL_TOWER_BUTTON) {
-        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * 0.5);
+        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
         SELL_TOWER_BUTTON.setAttribute('aria-label', `판매 (${refund}G 환급)`);
     }
     if (TARGET_PRIORITY_SELECT) {


### PR DESCRIPTION
## Summary
- `ENEMY_TYPE_DEFINITIONS`에 `spawnWeight`, `minWave`, `bossOnly` 스폰 필드를 추가하여 적 출현 확률을 데이터 주도 방식으로 전환
- `pickEnemyType()`의 하드코딩된 if-else 분기를 가중치 기반 랜덤 선택 알고리즘으로 리팩터링
- `getWaveEnemyComposition()`도 동일한 데이터 소스를 활용하도록 개선
- 판매 환급률 매직넘버 `0.5`를 `TOWER_SELL_REFUND_RATE` 상수로 추출 (game.js, ui.js)

closes #115

## Test plan
- [x] 기존 53개 테스트 전체 통과 확인 (`npm test`)
- [x] ESLint 경고만 존재, 에러 없음 (`npx eslint *.js tests/`)
- [x] Prettier 포맷 검증 완료
- [ ] 웨이브 1~2에서 일반 적만 출현하는지 확인
- [ ] 웨이브 3 이후 장갑/고속 적이 혼합 출현하는지 확인
- [ ] 웨이브 10, 20 등에서 보스가 마지막 적으로 출현하는지 확인
- [ ] 타워 판매 시 환급액이 투자 비용의 50%인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)