### PR TITLE
refactor: DOM 이벤트 버스 패턴 (#116)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -116,6 +116,26 @@ const TARGET_PRIORITIES = [
     { key: 'closest', label: '가까운 적' }
 ];
 
+const EventBus = {
+    _listeners: {},
+    on: function (event, fn) {
+        if (!this._listeners[event]) this._listeners[event] = [];
+        this._listeners[event].push(fn);
+    },
+    off: function (event, fn) {
+        if (!this._listeners[event]) return;
+        this._listeners[event] = this._listeners[event].filter(function (f) {
+            return f !== fn;
+        });
+    },
+    emit: function (event, data) {
+        if (!this._listeners[event]) return;
+        this._listeners[event].forEach(function (fn) {
+            fn(data);
+        });
+    }
+};
+
 const gameState = {
     gold: 100,
     lives: 20,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,7 @@ const gameGlobals = {
     ENEMY_TYPE_DEFINITIONS: 'readonly',
     ENEMY_TYPE_MAP: 'readonly',
     TARGET_PRIORITIES: 'readonly',
+    EventBus: 'readonly',
     gameState: 'readonly',
 
     // towers.js

--- a/game.js
+++ b/game.js
@@ -41,7 +41,7 @@ function setWave(targetWave) {
     if (WAVE_INPUT) {
         WAVE_INPUT.value = gameState.wave;
     }
-    updateWavePreview();
+    EventBus.emit('wave:changed');
 }
 
 function damageEnemyAtIndex(index, amount) {
@@ -64,7 +64,7 @@ function damageEnemyAtIndex(index, amount) {
         }
         enemies.splice(index, 1);
         gameState.gold = Math.min(999999, gameState.gold + enemy.reward);
-        updateGoldUI();
+        EventBus.emit('gold:changed');
         playSound('kill');
         return true;
     }
@@ -142,7 +142,7 @@ function showTowerStats(tower) {
     ensureTowerMetadata(tower);
     gameState.selectedTower = tower;
     TOWER_STATS_PANEL.classList.remove('hidden');
-    updateTowerStatsFields();
+    EventBus.emit('tower:selected');
     const def = getTowerDefinition(tower.type);
     announce(def.label + ' 포탑 정보');
 }
@@ -153,7 +153,7 @@ function showEnemyStats(enemy) {
     }
     gameState.selectedEnemy = enemy;
     ENEMY_STATS_PANEL.classList.remove('hidden');
-    updateEnemyStatsFields();
+    EventBus.emit('enemy:selected');
     const typeName = (enemy.enemyType || ENEMY_TYPE_DEFINITIONS[0]).label;
     announce(typeName + ' 적 정보');
 }
@@ -202,12 +202,12 @@ function upgradeTower(tower) {
     }
     gameState.gold -= cost;
     tower.spentGold = (tower.spentGold || 0) + cost;
-    updateGoldUI();
+    EventBus.emit('gold:changed');
     tower.level += 1;
     recalcTowerStats(tower);
     playSound('upgrade');
     if (gameState.selectedTower === tower) {
-        updateTowerStatsFields();
+        EventBus.emit('tower:selected');
     }
     const upgDef = getTowerDefinition(tower.type);
     announce(upgDef.label + ' 레벨 ' + tower.level + '로 업그레이드');
@@ -222,7 +222,7 @@ function sellTower(tower) {
     towers.splice(idx, 1);
     towerPositionSet.delete(keyFromGrid(tower.x, tower.y));
     gameState.gold = Math.min(999999, gameState.gold + refund);
-    updateGoldUI();
+    EventBus.emit('gold:changed');
     if (gameState.selectedTower === tower) hideTowerStats();
     playSound('build');
     const sellDef = getTowerDefinition(tower.type);
@@ -261,7 +261,7 @@ function showDefeatDialog() {
             RETRY_BUTTON.focus();
         }
     }
-    updateWavePreview(0);
+    EventBus.emit('wave:changed', { remaining: 0 });
     announce('패배했습니다');
 }
 
@@ -411,7 +411,7 @@ function resetGame() {
     clearCurrentWave();
     gameState.selectedTowerType = DEFAULT_TOWER_TYPE;
     setSelectedTowerButton(gameState.selectedTowerType);
-    updateGoldUI();
+    EventBus.emit('gold:changed');
     if (LIVES_LABEL) LIVES_LABEL.textContent = gameState.lives;
     if (WAVE_LABEL) WAVE_LABEL.textContent = gameState.wave;
     if (WAVE_INPUT) {
@@ -425,7 +425,7 @@ function resetGame() {
     } else {
         setBuildPanelCollapsed(false);
     }
-    updateWavePreview();
+    EventBus.emit('wave:changed');
     elapsedTime = 0;
     lastTime = performance.now();
     cachedNoiseBuffer = null;
@@ -443,7 +443,7 @@ function startWave() {
     if (WAVE_INPUT) {
         WAVE_INPUT.value = gameState.wave;
     }
-    updateWavePreview(gameState.enemiesToSpawn + enemies.length);
+    EventBus.emit('wave:changed', { remaining: gameState.enemiesToSpawn + enemies.length });
     announce(`웨이브 ${gameState.wave} 시작`);
 }
 
@@ -896,14 +896,14 @@ function update(dt) {
             gameState.nextWaveTimer = 4;
             var waveBonus = WAVE_CLEAR_BONUS_BASE + gameState.wave * WAVE_CLEAR_BONUS_PER_WAVE;
             gameState.gold = Math.min(gameState.gold + waveBonus, 999999);
-            updateGoldUI();
+            EventBus.emit('gold:changed');
             announce('웨이브 ' + gameState.wave + ' 클리어! 보너스 ' + waveBonus + ' 골드');
             gameState.wave = Math.min(gameState.wave + 1, WAVE_MAX);
             if (WAVE_LABEL) WAVE_LABEL.textContent = gameState.wave;
             if (WAVE_INPUT) {
                 WAVE_INPUT.value = gameState.wave;
             }
-            updateWavePreview();
+            EventBus.emit('wave:changed');
         }
     } else if (gameState.nextWaveTimer > 0) {
         gameState.nextWaveTimer -= dt;
@@ -1067,10 +1067,13 @@ function update(dt) {
     }
 
     if (gameState.selectedEnemy) {
-        updateEnemyStatsFields();
+        EventBus.emit('enemy:selected');
     }
     if (gameState.selectedTower) {
-        updateTowerStatsFields();
+        EventBus.emit('tower:selected');
     }
-    updateWavePreview(gameState.waveInProgress ? gameState.enemiesToSpawn + enemies.length : null);
+    EventBus.emit(
+        'wave:changed',
+        gameState.waveInProgress ? { remaining: gameState.enemiesToSpawn + enemies.length } : null
+    );
 }

--- a/main.js
+++ b/main.js
@@ -91,7 +91,7 @@ function handlePointerDown(canvasX, canvasY, isRightClick) {
     }
 
     gameState.gold -= cost;
-    updateGoldUI();
+    EventBus.emit('gold:changed');
     const towerData = createTowerData(x, y, towerDef.id);
     towers.push(towerData);
     towerPositionSet.add(keyFromGrid(x, y));
@@ -278,7 +278,7 @@ if (GOLD_APPLY_BUTTON && GOLD_INPUT) {
             return;
         }
         gameState.gold = Math.max(0, Math.min(999999, Math.floor(value)));
-        updateGoldUI();
+        EventBus.emit('gold:changed');
     };
     GOLD_APPLY_BUTTON.addEventListener('click', applyGold);
     GOLD_INPUT.addEventListener('keydown', (event) => {
@@ -292,7 +292,7 @@ GOLD_ADJUST_BUTTONS.forEach((button) => {
     button.addEventListener('click', () => {
         const delta = Number(button.dataset.delta) || 0;
         gameState.gold = Math.min(999999, Math.max(0, gameState.gold + delta));
-        updateGoldUI();
+        EventBus.emit('gold:changed');
     });
 });
 
@@ -526,8 +526,8 @@ function startLoop() {
 }
 
 updateSpeedControls();
-updateWavePreview();
-updateGoldUI();
+EventBus.emit('wave:changed');
+EventBus.emit('gold:changed');
 if (WAVE_INPUT) {
     WAVE_INPUT.value = gameState.wave;
 }

--- a/ui.js
+++ b/ui.js
@@ -425,3 +425,11 @@ function updateEnemyStatsFields() {
     setTextIfChanged(ENEMY_STATS_FIELDS.speed, `${(gameState.selectedEnemy.speed / TILE_SIZE).toFixed(2)} 타일/초`);
     setTextIfChanged(ENEMY_STATS_FIELDS.reward, `${gameState.selectedEnemy.reward}`);
 }
+
+// ── EventBus listeners ──────────────────────────────────────────────────────
+EventBus.on('gold:changed', updateGoldUI);
+EventBus.on('wave:changed', function (data) {
+    updateWavePreview(data != null ? data.remaining : undefined);
+});
+EventBus.on('tower:selected', updateTowerStatsFields);
+EventBus.on('enemy:selected', updateEnemyStatsFields);


### PR DESCRIPTION
## Summary
- `constants.js`에 경량 `EventBus` 객체 추가 (`on`, `off`, `emit` 메서드)
- `game.js`와 `main.js`에서 `updateGoldUI()`, `updateWavePreview()`, `updateTowerStatsFields()`, `updateEnemyStatsFields()` 직접 호출을 `EventBus.emit()` 호출로 교체
- `ui.js` 하단에 `EventBus.on()` 리스너 등록으로 UI 함수와 게임 로직 디커플링
- `eslint.config.mjs` 글로벌에 `EventBus` 추가

## Test plan
- [x] 기존 53개 테스트 전부 통과 확인
- [x] ESLint 새 에러 없음 확인
- [x] Prettier 포맷 확인
- [ ] 브라우저에서 골드 변경, 웨이브 진행, 포탑/적 선택 시 UI 업데이트 정상 동작 확인
- [ ] 포탑 업그레이드/판매 시 골드 및 포탑 스탯 UI 반영 확인

closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)