### PR TITLE
fix+enhancement: projectileSpeed fallback + 업그레이드 스탯 미리보기 (#159, #138)

### DIFF
--- a/game.js
+++ b/game.js
@@ -635,7 +635,7 @@ function attackShotgun(tower, def, dirX, dirY, baseAngle) {
         const ratio = pellets === 1 ? 0 : i / (pellets - 1) - 0.5;
         const jitter = (Math.random() - 0.5) * 0.35;
         const angle = baseAngle + (ratio + jitter) * spread;
-        const speed = def.projectileSpeed * (0.9 + Math.random() * 0.3);
+        const speed = (def.projectileSpeed || 580) * (0.9 + Math.random() * 0.3);
         const color = getProjectileColor(def, tower.level);
         spawnProjectile({
             x: tower.worldX,
@@ -659,7 +659,7 @@ function attackShotgun(tower, def, dirX, dirY, baseAngle) {
 
 function attackBeam(tower, def, dirX, dirY, baseAngle) {
     const ls = def.levelScaling || {};
-    const speed = def.projectileSpeed + (tower.level - 1) * (ls.speedPerLevel ?? 25);
+    const speed = (def.projectileSpeed || 580) + (tower.level - 1) * (ls.speedPerLevel ?? 25);
     const color = getProjectileColor(def, tower.level);
     spawnProjectile({
         x: tower.worldX,
@@ -681,7 +681,7 @@ function attackBeam(tower, def, dirX, dirY, baseAngle) {
 
 function attackBurst(tower, def, dirX, dirY, baseAngle) {
     const ls = def.levelScaling || {};
-    const speed = def.projectileSpeed + (tower.level - 1) * (ls.speedPerLevel ?? 25);
+    const speed = (def.projectileSpeed || 580) + (tower.level - 1) * (ls.speedPerLevel ?? 25);
     const burstCount = def.burstCount || 3;
     const delayStep = def.burstDelay ?? 0.07;
     const color = getProjectileColor(def, tower.level);
@@ -710,7 +710,7 @@ function attackBurst(tower, def, dirX, dirY, baseAngle) {
 
 function attackExplosive(tower, def, dirX, dirY, baseAngle) {
     const ls = def.levelScaling || {};
-    const speed = def.projectileSpeed + (tower.level - 1) * (ls.speedPerLevel ?? 20);
+    const speed = (def.projectileSpeed || 580) + (tower.level - 1) * (ls.speedPerLevel ?? 20);
     const color = getProjectileColor(def, tower.level);
     spawnProjectile({
         x: tower.worldX,
@@ -738,7 +738,7 @@ function attackExplosive(tower, def, dirX, dirY, baseAngle) {
 
 function attackMortar(tower, def, dirX, dirY, baseAngle) {
     const ls = def.levelScaling || {};
-    const speed = def.projectileSpeed + (tower.level - 1) * (ls.speedPerLevel ?? 12);
+    const speed = (def.projectileSpeed || 580) + (tower.level - 1) * (ls.speedPerLevel ?? 12);
     const lift = def.mortarLift + (tower.level - 1) * (ls.liftPerLevel ?? 12);
     const color = getProjectileColor(def, tower.level);
     spawnProjectile({

--- a/towers.js
+++ b/towers.js
@@ -272,7 +272,8 @@ const TOWER_TYPES = {
         turnSpeed: 9.5,
         outline: '#0b3c4f',
         levelColors: ['#b1f4ff', '#9be9ff', '#84deff', '#6dd2ff', '#55c6ff', '#3ab8ff', '#24a7f5'],
-        projectileColors: ['#e6fdff', '#d0f8ff', '#bbf3ff', '#a4ecff', '#90e5ff', '#79ddff', '#61d3ff']
+        projectileColors: ['#e6fdff', '#d0f8ff', '#bbf3ff', '#a4ecff', '#90e5ff', '#79ddff', '#61d3ff'],
+        levelScaling: {}
     },
     mortar: {
         id: 'mortar',

--- a/ui.js
+++ b/ui.js
@@ -375,18 +375,47 @@ function updateTowerStatsFields() {
     const def = getTowerDefinition(gameState.selectedTower.type);
     setTextIfChanged(TOWER_STATS_FIELDS.type, def.label);
     setTextIfChanged(TOWER_STATS_FIELDS.position, `${gameState.selectedTower.x}, ${gameState.selectedTower.y}`);
+    const level = gameState.selectedTower.level;
+    const atMax = level >= TOWER_MAX_LEVEL;
     if (TOWER_STATS_FIELDS.range) {
-        const tiles = (gameState.selectedTower.range / TILE_SIZE).toFixed(1);
-        setTextIfChanged(TOWER_STATS_FIELDS.range, `${Math.round(gameState.selectedTower.range)}px (${tiles}타일)`);
+        const currentRange = gameState.selectedTower.range;
+        const tiles = (currentRange / TILE_SIZE).toFixed(1);
+        let text = `${Math.round(currentRange)}px (${tiles}타일)`;
+        if (!atMax) {
+            const nextRange = def.range + (def.rangeGrowth || 0) * level;
+            const nextTiles = (nextRange / TILE_SIZE).toFixed(1);
+            text += ` → ${Math.round(nextRange)}px (${nextTiles}타일)`;
+        }
+        setTextIfChanged(TOWER_STATS_FIELDS.range, text);
     }
     if (TOWER_STATS_FIELDS.fireDelay) {
-        const text =
-            def.attackPattern === 'laser'
-                ? `지속 (${(gameState.selectedTower.damage * (def.sustainMultiplier || 1)).toFixed(1)} DPS)`
-                : `${gameState.selectedTower.fireDelay.toFixed(2)}초`;
-        setTextIfChanged(TOWER_STATS_FIELDS.fireDelay, text);
+        if (def.attackPattern === 'laser') {
+            const currentDps = (gameState.selectedTower.damage * (def.sustainMultiplier || 1)).toFixed(1);
+            let text = `지속 (${currentDps} DPS)`;
+            if (!atMax) {
+                const nextDamage = calculateTowerDamage(def, level + 1);
+                const nextDps = (nextDamage * (def.sustainMultiplier || 1)).toFixed(1);
+                text += ` → ${nextDps} DPS`;
+            }
+            setTextIfChanged(TOWER_STATS_FIELDS.fireDelay, text);
+        } else {
+            const currentDelay = gameState.selectedTower.fireDelay.toFixed(2);
+            let text = `${currentDelay}초`;
+            if (!atMax) {
+                const nextDelay = Math.max(def.fireDelay + (def.fireDelayGrowth || 0) * level, 0.05).toFixed(2);
+                text += ` → ${nextDelay}초`;
+            }
+            setTextIfChanged(TOWER_STATS_FIELDS.fireDelay, text);
+        }
     }
-    setTextIfChanged(TOWER_STATS_FIELDS.damage, formatNumber(gameState.selectedTower.damage));
+    {
+        let dmgText = formatNumber(gameState.selectedTower.damage);
+        if (!atMax) {
+            const nextDamage = calculateTowerDamage(def, level + 1);
+            dmgText += ` → ${formatNumber(nextDamage)}`;
+        }
+        setTextIfChanged(TOWER_STATS_FIELDS.damage, dmgText);
+    }
     setTextIfChanged(TOWER_STATS_FIELDS.level, '' + gameState.selectedTower.level);
     if (TOWER_STATS_FIELDS.upgradeCost) {
         const cost = gameState.selectedTower.upgradeCost;


### PR DESCRIPTION
## Summary
- #159 공격 함수 5개에 projectileSpeed fallback `|| 580` 통일 + laser 타워에 빈 levelScaling 추가
- #138 포탑 스탯 패널에 다음 레벨 사거리/발사간격/데미지 미리보기 (`현재 → 다음`)

Closes #159, closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)