### PR TITLE
fix: || 폴백 falsy 0 오판 → ?? nullish coalescing (#154)

### DIFF
--- a/game.js
+++ b/game.js
@@ -197,11 +197,11 @@ function upgradeTower(tower) {
         return false;
     }
     const cost = tower.upgradeCost;
-    if (cost == null || gameState.gold < cost) {
+    if (cost === null || cost === undefined || gameState.gold < cost) {
         return false;
     }
     gameState.gold -= cost;
-    tower.spentGold = (tower.spentGold || 0) + cost;
+    tower.spentGold = (tower.spentGold ?? 0) + cost;
     EventBus.emit('gold:changed');
     tower.level += 1;
     recalcTowerStats(tower);
@@ -218,7 +218,7 @@ function sellTower(tower) {
     if (gameState.gameOver) return false;
     const idx = towers.indexOf(tower);
     if (idx === -1) return false;
-    const refund = Math.floor((tower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
+    const refund = Math.floor((tower.spentGold ?? 0) * TOWER_SELL_REFUND_RATE);
     towers.splice(idx, 1);
     towerPositionSet.delete(keyFromGrid(tower.x, tower.y));
     gameState.gold = Math.min(999999, gameState.gold + refund);
@@ -378,7 +378,7 @@ function populateMapList() {
 
         var paramsEl = document.createElement('span');
         paramsEl.className = 'map-card-params';
-        paramsEl.textContent = '골드: ' + (mapDef.initialGold || 100) + ' / 생명력: ' + (mapDef.initialLives || 20);
+        paramsEl.textContent = '골드: ' + (mapDef.initialGold ?? 100) + ' / 생명력: ' + (mapDef.initialLives ?? 20);
 
         card.setAttribute('aria-pressed', String(mapDef.id === activeMapId));
         card.append(nameEl, previewCanvas, diffEl, paramsEl);
@@ -399,8 +399,8 @@ function resetGame() {
     buildMapData(activeMapId);
     staticLayer = null;
     var currentMapDef = MAP_DEFINITIONS[activeMapId] || MAP_DEFINITIONS['map1'];
-    gameState.gold = currentMapDef.initialGold || 100;
-    gameState.lives = currentMapDef.initialLives || 20;
+    gameState.gold = currentMapDef.initialGold ?? 100;
+    gameState.lives = currentMapDef.initialLives ?? 20;
     gameState.wave = 1;
     gameState.gameOver = false;
     gameState.paused = false;
@@ -480,7 +480,7 @@ function createTowerData(x, y, typeId) {
         flashTimer: 0,
         recoil: 0,
         auraOffset: Math.random() * Math.PI * 2,
-        spentGold: def.cost || 0,
+        spentGold: def.cost ?? 0,
         targetPriority: 'first'
     };
 }

--- a/main.js
+++ b/main.js
@@ -84,7 +84,7 @@ function handlePointerDown(canvasX, canvasY, isRightClick) {
     }
 
     const towerDef = getTowerDefinition(gameState.selectedTowerType);
-    const cost = towerDef.cost || 25;
+    const cost = towerDef.cost ?? 25;
     if (gameState.gold < cost) {
         flashGoldInsufficient();
         return;
@@ -452,7 +452,7 @@ document.addEventListener('keydown', (event) => {
             const success = upgradeTower(gameState.selectedTower);
             if (!success && gameState.selectedTower) {
                 const cost = gameState.selectedTower.upgradeCost;
-                if (cost != null && gameState.gold < cost) {
+                if (cost !== null && cost !== undefined && gameState.gold < cost) {
                     flashGoldInsufficient();
                 }
             }

--- a/ui.js
+++ b/ui.js
@@ -419,21 +419,21 @@ function updateTowerStatsFields() {
     setTextIfChanged(TOWER_STATS_FIELDS.level, '' + gameState.selectedTower.level);
     if (TOWER_STATS_FIELDS.upgradeCost) {
         const cost = gameState.selectedTower.upgradeCost;
-        setTextIfChanged(TOWER_STATS_FIELDS.upgradeCost, cost == null ? 'MAX' : formatNumber(cost));
+        setTextIfChanged(TOWER_STATS_FIELDS.upgradeCost, cost === null ? 'MAX' : formatNumber(cost));
     }
     if (UPGRADE_TOWER_BUTTON) {
-        const atMax = gameState.selectedTower.upgradeCost == null;
+        const atMax = gameState.selectedTower.upgradeCost === null;
         UPGRADE_TOWER_BUTTON.disabled = atMax || gameState.gameOver;
         const label = atMax ? '최대 레벨' : `업그레이드 (${formatNumber(gameState.selectedTower.upgradeCost)}G)`;
         setTextIfChanged(UPGRADE_TOWER_BUTTON, label);
         UPGRADE_TOWER_BUTTON.setAttribute('aria-label', label);
     }
     if (TOWER_STATS_FIELDS.sellRefund) {
-        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
+        const refund = Math.floor((gameState.selectedTower.spentGold ?? 0) * TOWER_SELL_REFUND_RATE);
         setTextIfChanged(TOWER_STATS_FIELDS.sellRefund, formatNumber(refund));
     }
     if (SELL_TOWER_BUTTON) {
-        const refund = Math.floor((gameState.selectedTower.spentGold || 0) * TOWER_SELL_REFUND_RATE);
+        const refund = Math.floor((gameState.selectedTower.spentGold ?? 0) * TOWER_SELL_REFUND_RATE);
         SELL_TOWER_BUTTON.setAttribute('aria-label', `판매 (${refund}G 환급)`);
     }
     if (TARGET_PRIORITY_SELECT) {


### PR DESCRIPTION
## Summary
- game.js: initialGold/Lives, spentGold, cost의 `||` → `??` 전환 (6개소)
- main.js: towerDef.cost `||` → `??`, cost `!= null` → `!== null && !== undefined`
- ui.js: upgradeCost `== null` → `=== null`, spentGold `||` → `??` (4개소)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)