### PR TITLE
fix: 크로스파일 전역 변수 로드 순서 의존 해소 (#161)

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -94,6 +94,11 @@ function playToneSequence(steps) {
 let cachedNoiseBuffer = null;
 let cachedNoiseDuration = 0;
 
+function resetAudioCache() {
+    cachedNoiseBuffer = null;
+    cachedNoiseDuration = 0;
+}
+
 function playNoise(duration = 0.25, volume = 0.24) {
     if (soundMuted) return;
     const ctx = ensureAudioContext();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,7 @@ const gameGlobals = {
     calculateTowerDamage: 'readonly',
     calculateUpgradeCost: 'readonly',
     recalcTowerStats: 'readonly',
+    NUMBER_FORMAT: 'readonly',
 
     // map.js
     MAP_DEFINITIONS: 'readonly',
@@ -79,7 +80,6 @@ const gameGlobals = {
     _touchStartY: 'writable',
     LONG_PRESS_DURATION: 'readonly',
     LONG_PRESS_MOVE_THRESHOLD: 'readonly',
-    NUMBER_FORMAT: 'readonly',
     GOLD_LABEL: 'readonly',
     LIVES_LABEL: 'readonly',
     WAVE_LABEL: 'readonly',
@@ -125,6 +125,7 @@ const gameGlobals = {
     populateTowerList: 'readonly',
     buildPanelCollapsed: 'writable',
     buildPanelUserOverride: 'writable',
+    resetBuildPanelOverride: 'readonly',
     setBuildPanelCollapsed: 'readonly',
     getWaveEnemyComposition: 'readonly',
     getWaveEnemyCount: 'readonly',
@@ -145,6 +146,7 @@ const gameGlobals = {
     playToneSequence: 'readonly',
     cachedNoiseBuffer: 'writable',
     cachedNoiseDuration: 'writable',
+    resetAudioCache: 'readonly',
     playNoise: 'readonly',
     SOUND_LIBRARY: 'readonly',
     updateSoundToggle: 'readonly',

--- a/game.js
+++ b/game.js
@@ -420,7 +420,7 @@ function resetGame() {
     }
     hideDefeatDialog();
     setGameSpeed(1);
-    buildPanelUserOverride = false;
+    resetBuildPanelOverride();
     if (typeof window !== 'undefined' && window.innerWidth < AUTOCOLLAPSE_WIDTH) {
         setBuildPanelCollapsed(true);
     } else {
@@ -429,10 +429,9 @@ function resetGame() {
     EventBus.emit('wave:changed');
     elapsedTime = 0;
     lastTime = performance.now();
-    cachedNoiseBuffer = null;
+    resetAudioCache();
     gameState.gameLoopHalted = false;
     loopErrorCount = 0;
-    cachedNoiseDuration = 0;
 }
 
 function startWave() {

--- a/ui.js
+++ b/ui.js
@@ -14,8 +14,6 @@ let _touchStartY = 0;
 const LONG_PRESS_DURATION = 500;
 const LONG_PRESS_MOVE_THRESHOLD = 10;
 
-const NUMBER_FORMAT = new Intl.NumberFormat('ko-KR');
-
 const GOLD_LABEL = document.getElementById('gold');
 const LIVES_LABEL = document.getElementById('lives');
 const WAVE_LABEL = document.getElementById('wave');
@@ -250,6 +248,10 @@ if (TOWER_LIST_CONTAINER) {
 
 let buildPanelCollapsed = false;
 let buildPanelUserOverride = false;
+
+function resetBuildPanelOverride() {
+    buildPanelUserOverride = false;
+}
 
 function setBuildPanelCollapsed(state, options = {}) {
     if (!BUILD_CONTAINER) {

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,7 @@
 let TOWER_SELECTOR_BUTTONS = [];
 
+const NUMBER_FORMAT = new Intl.NumberFormat('ko-KR');
+
 function gridFromPosition(point) {
     return {
         x: Math.floor(point.x / TILE_SIZE),


### PR DESCRIPTION
## Summary
- NUMBER_FORMAT을 ui.js에서 utils.js로 이동 (정의와 사용처 동일 파일로 통일)
- audio.js에 `resetAudioCache()` 함수 추가, game.js의 직접 변수 조작 제거
- ui.js에 `resetBuildPanelOverride()` 함수 추가, game.js의 직접 변수 조작 제거
- eslint.config.mjs globals 업데이트 (새 함수 추가)

Closes #161

## Test plan
- [x] 기존 92개 테스트 전체 통과
- [x] ESLint 0 errors
- [ ] 게임 리셋 후 사운드 정상 재생 확인
- [ ] 게임 리셋 후 빌드 패널 접힘 상태 확인
- [ ] 적 HP 표시 NUMBER_FORMAT 정상 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)