### PR TITLE
feat+refactor: 패배 화면 통계 + 웨이브 함수 모듈 이동 (#134, #151)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -157,5 +157,8 @@ const gameState = {
     selectedEnemy: null,
     selectedTowerType: DEFAULT_TOWER_TYPE,
     hoverTile: null,
-    buildFailFlash: null
+    buildFailFlash: null,
+    totalKills: 0,
+    totalGoldSpent: 0,
+    towersBuilt: 0
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,8 @@ const gameGlobals = {
     calculateUpgradeCost: 'readonly',
     recalcTowerStats: 'readonly',
     NUMBER_FORMAT: 'readonly',
+    getWaveEnemyCount: 'readonly',
+    getWaveEnemyStats: 'readonly',
 
     // map.js
     MAP_DEFINITIONS: 'readonly',
@@ -128,8 +130,6 @@ const gameGlobals = {
     resetBuildPanelOverride: 'readonly',
     setBuildPanelCollapsed: 'readonly',
     getWaveEnemyComposition: 'readonly',
-    getWaveEnemyCount: 'readonly',
-    getWaveEnemyStats: 'readonly',
     updateWavePreview: 'readonly',
     updateSpeedControls: 'readonly',
     setGameSpeed: 'readonly',

--- a/game.js
+++ b/game.js
@@ -63,6 +63,7 @@ function damageEnemyAtIndex(index, amount) {
             hideEnemyStats();
         }
         enemies.splice(index, 1);
+        gameState.totalKills++;
         gameState.gold = Math.min(999999, gameState.gold + enemy.reward);
         EventBus.emit('gold:changed');
         playSound('kill');
@@ -201,6 +202,7 @@ function upgradeTower(tower) {
         return false;
     }
     gameState.gold -= cost;
+    gameState.totalGoldSpent += cost;
     tower.spentGold = (tower.spentGold ?? 0) + cost;
     EventBus.emit('gold:changed');
     tower.level += 1;
@@ -256,6 +258,14 @@ function showDefeatDialog() {
     setGameSpeed(1);
     if (DEFEAT_OVERLAY) {
         _defeatPreviousFocus = document.activeElement;
+        var statWave = document.getElementById('stat-wave');
+        var statKills = document.getElementById('stat-kills');
+        var statTowers = document.getElementById('stat-towers');
+        var statGoldSpent = document.getElementById('stat-gold-spent');
+        if (statWave) statWave.textContent = gameState.wave;
+        if (statKills) statKills.textContent = gameState.totalKills;
+        if (statTowers) statTowers.textContent = gameState.towersBuilt;
+        if (statGoldSpent) statGoldSpent.textContent = formatNumber(gameState.totalGoldSpent);
         DEFEAT_OVERLAY.classList.remove('hidden');
         if (RETRY_BUTTON) {
             RETRY_BUTTON.focus();
@@ -406,6 +416,9 @@ function resetGame() {
     gameState.paused = false;
     gameState.hoverTile = null;
     gameState.buildFailFlash = null;
+    gameState.totalKills = 0;
+    gameState.totalGoldSpent = 0;
+    gameState.towersBuilt = 0;
     hideAllStats();
     towers.length = 0;
     towerPositionSet.clear();

--- a/index.html
+++ b/index.html
@@ -173,7 +173,12 @@
         <div id="defeat-overlay" class="overlay hidden" role="dialog" aria-modal="true" aria-label="패배">
             <div class="overlay-content">
                 <h2>패배했습니다</h2>
-                <p>다시 시도하시겠습니까?</p>
+                <div id="defeat-stats" class="defeat-stats">
+                    <p>도달 웨이브: <span id="stat-wave">-</span></p>
+                    <p>처치 수: <span id="stat-kills">-</span></p>
+                    <p>설치 포탑: <span id="stat-towers">-</span></p>
+                    <p>소비 골드: <span id="stat-gold-spent">-</span></p>
+                </div>
                 <div class="overlay-actions">
                     <button type="button" id="retry-button">다시 시작</button>
                     <button type="button" id="cancel-retry-button">닫기</button>

--- a/main.js
+++ b/main.js
@@ -91,6 +91,8 @@ function handlePointerDown(canvasX, canvasY, isRightClick) {
     }
 
     gameState.gold -= cost;
+    gameState.totalGoldSpent += cost;
+    gameState.towersBuilt++;
     EventBus.emit('gold:changed');
     const towerData = createTowerData(x, y, towerDef.id);
     towers.push(towerData);

--- a/style.css
+++ b/style.css
@@ -448,6 +448,23 @@ canvas {
     color: var(--text-muted);
 }
 
+.defeat-stats {
+    margin: 16px 0;
+    text-align: left;
+}
+
+.defeat-stats p {
+    margin: 4px 0;
+    color: var(--text-muted);
+    display: flex;
+    justify-content: space-between;
+}
+
+.defeat-stats span {
+    color: var(--text-primary, #e2e2e2);
+    font-weight: 600;
+}
+
 .overlay-actions {
     display: flex;
     gap: 12px;

--- a/ui.js
+++ b/ui.js
@@ -279,20 +279,6 @@ function setBuildPanelCollapsed(state, options = {}) {
     }
 }
 
-function getWaveEnemyCount(waveNumber) {
-    return 8 + Math.floor(waveNumber * 1.5);
-}
-
-function getWaveEnemyStats(waveNumber, enemyType = ENEMY_TYPE_DEFINITIONS[0]) {
-    const growth = Math.pow(ENEMY_HP_GROWTH_RATE, Math.max(0, waveNumber - 1));
-    const hp = Math.round(Math.min(ENEMY_BASE_HP * growth * enemyType.hpMult, Number.MAX_SAFE_INTEGER));
-    const speedBonus = 1 + Math.min(waveNumber * 0.005, 0.5);
-    const speed = Math.round(ENEMY_SPEED * enemyType.speedMult * speedBonus);
-    const reward = Math.round((ENEMY_BASE_REWARD + waveNumber * 1.5) * enemyType.rewardMult);
-    const count = getWaveEnemyCount(waveNumber);
-    return { hp, speed, reward, count };
-}
-
 function updateWavePreview(remainingOverride) {
     if (!WAVE_PREVIEW_FIELDS) {
         return;

--- a/utils.js
+++ b/utils.js
@@ -144,6 +144,21 @@ function calculateUpgradeCost(definition, level) {
     return Math.min(Math.round(base * Math.pow(TOWER_UPGRADE_COST_MULTIPLIER, level - 1)), Number.MAX_SAFE_INTEGER);
 }
 
+function getWaveEnemyCount(waveNumber) {
+    return 8 + Math.floor(waveNumber * 1.5);
+}
+
+function getWaveEnemyStats(waveNumber, enemyType) {
+    if (!enemyType) enemyType = ENEMY_TYPE_DEFINITIONS[0];
+    const growth = Math.pow(ENEMY_HP_GROWTH_RATE, Math.max(0, waveNumber - 1));
+    const hp = Math.round(Math.min(ENEMY_BASE_HP * growth * enemyType.hpMult, Number.MAX_SAFE_INTEGER));
+    const speedBonus = 1 + Math.min(waveNumber * 0.005, 0.5);
+    const speed = Math.round(ENEMY_SPEED * enemyType.speedMult * speedBonus);
+    const reward = Math.round((ENEMY_BASE_REWARD + waveNumber * 1.5) * enemyType.rewardMult);
+    const count = getWaveEnemyCount(waveNumber);
+    return { hp, speed, reward, count };
+}
+
 function recalcTowerStats(tower) {
     const def = getTowerDefinition(tower.type);
     tower.range = def.range + (def.rangeGrowth || 0) * (tower.level - 1);


### PR DESCRIPTION
## Summary
- #134: 패배 화면에 도달 웨이브·처치 수·설치 포탑·소비 골드 통계 표시
- #151: getWaveEnemyCount/getWaveEnemyStats를 ui.js에서 utils.js로 이동 (의존 방향 정상화)

Closes #134
Closes #151

## Test plan
- [x] 기존 92개 테스트 전체 통과
- [x] ESLint 0 errors
- [ ] 게임 패배 시 통계 정상 표시 확인
- [ ] 다시 시작 후 카운터 초기화 확인
- [ ] 웨이브 프리뷰 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)