### PR TITLE
fix+dx+test: Batch B — DX/테스트 5건 (#182,#190,#191,#193,#180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm test
+      - run: npm run test:coverage
       - run: npm run lint --if-present
       - run: npm run format:check --if-present

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -280,7 +280,10 @@ export default [
         rules: {
             'no-undef': 'error',
             'no-unused-vars': 'warn',
-            'no-redeclare': 'warn'
+            'no-redeclare': 'warn',
+            complexity: ['warn', 15],
+            'max-depth': ['warn', 4],
+            'max-lines-per-function': ['warn', { max: 100, skipBlankLines: true, skipComments: true }]
         }
     },
     {
@@ -296,7 +299,10 @@ export default [
         rules: {
             'no-undef': 'error',
             'no-unused-vars': 'warn',
-            'no-redeclare': 'warn'
+            'no-redeclare': 'warn',
+            complexity: ['warn', 15],
+            'max-depth': ['warn', 4],
+            'max-lines-per-function': ['warn', { max: 100, skipBlankLines: true, skipComments: true }]
         }
     },
     {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "node --test tests/smoke.test.js tests/unit.test.js",
     "test:coverage": "node --test --experimental-test-coverage tests/smoke.test.js tests/unit.test.js",
-    "lint": "eslint *.js tests/**/*.js",
+    "lint": "eslint --max-warnings 0 *.js tests/**/*.js",
     "lint:fix": "eslint --fix *.js tests/**/*.js",
     "check-globals": "node scripts/check-globals.mjs",
     "format": "prettier --write \"*.js\" \"*.mjs\" \"tests/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:coverage": "node --test --experimental-test-coverage tests/smoke.test.js tests/unit.test.js",
     "lint": "eslint *.js tests/**/*.js",
     "lint:fix": "eslint --fix *.js tests/**/*.js",
+    "check-globals": "node scripts/check-globals.mjs",
     "format": "prettier --write \"*.js\" \"*.mjs\" \"tests/**/*.js\"",
     "format:check": "prettier --check \"*.js\" \"*.mjs\" \"tests/**/*.js\"",
     "prepare": "husky"

--- a/scripts/check-globals.mjs
+++ b/scripts/check-globals.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * #193: gameGlobals 자동 검증 스크립트
+ *
+ * 소스 파일에서 최상위 function, const, let 선언을 파싱하고
+ * eslint.config.mjs의 gameGlobals 키와 비교하여
+ * 누락(missing)과 과잉(extraneous)을 출력합니다.
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// 1. 소스 파일에서 최상위 선언 파싱
+const SOURCE_FILES = [
+    'constants.js',
+    'towers.js',
+    'utils.js',
+    'map.js',
+    'ui.js',
+    'audio.js',
+    'combat.js',
+    'overlay.js',
+    'game.js',
+    'update.js',
+    'renderer.js',
+    'main.js'
+];
+
+const declPattern = /^(?:function\s+(\w+)|(?:const|let)\s+(\w+))/;
+
+const sourceGlobals = new Set();
+
+for (const file of SOURCE_FILES) {
+    const filePath = join(ROOT, file);
+    let content;
+    try {
+        content = readFileSync(filePath, 'utf-8');
+    } catch {
+        console.warn(`Warning: ${file} not found, skipping`);
+        continue;
+    }
+    const lines = content.split('\n');
+    for (const line of lines) {
+        const match = line.match(declPattern);
+        if (match) {
+            const name = match[1] || match[2];
+            sourceGlobals.add(name);
+        }
+    }
+}
+
+// 2. eslint.config.mjs에서 gameGlobals 키 추출
+const eslintConfigPath = join(ROOT, 'eslint.config.mjs');
+const eslintContent = readFileSync(eslintConfigPath, 'utf-8');
+
+// gameGlobals 블록에서 키 추출: "키: '값'" 패턴
+const globalKeyPattern = /^\s+(\w+):\s*'(?:readonly|writable)'/gm;
+const configGlobals = new Set();
+let keyMatch;
+while ((keyMatch = globalKeyPattern.exec(eslintContent)) !== null) {
+    configGlobals.add(keyMatch[1]);
+}
+
+// 3. 비교
+const missing = []; // 소스에 있으나 config에 없음
+const extraneous = []; // config에 있으나 소스에 없음
+
+for (const name of sourceGlobals) {
+    if (!configGlobals.has(name)) {
+        missing.push(name);
+    }
+}
+
+for (const name of configGlobals) {
+    if (!sourceGlobals.has(name)) {
+        extraneous.push(name);
+    }
+}
+
+// 4. 결과 출력
+let hasIssues = false;
+
+if (missing.length > 0) {
+    hasIssues = true;
+    console.log(`\n❌ 소스에 있으나 gameGlobals에 누락된 선언 (${missing.length}개):`);
+    for (const name of missing.sort()) {
+        console.log(`  - ${name}`);
+    }
+}
+
+if (extraneous.length > 0) {
+    hasIssues = true;
+    console.log(`\n⚠️  gameGlobals에 있으나 소스에서 찾을 수 없는 선언 (${extraneous.length}개):`);
+    for (const name of extraneous.sort()) {
+        console.log(`  - ${name}`);
+    }
+}
+
+if (!hasIssues) {
+    console.log('✅ gameGlobals와 소스 파일 선언이 일치합니다.');
+}
+
+console.log(`\n총 소스 선언: ${sourceGlobals.size}개, gameGlobals 키: ${configGlobals.size}개`);
+
+process.exit(hasIssues ? 1 : 0);

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -1758,4 +1758,138 @@ describe('Unit tests', () => {
         towerPositionSet.clear();
         projectiles.length = 0;
     });
+
+    // ── #191: utils.js 순수 함수 테스트 ──
+
+    it('#191: formatNumber 정상 정수', () => {
+        assert.strictEqual(formatNumber(0), '0', '#191: formatNumber(0) = "0"');
+        assert.strictEqual(formatNumber(42), '42', '#191: formatNumber(42) = "42"');
+        assert.strictEqual(formatNumber(-5), '-5', '#191: formatNumber(-5) = "-5"');
+        assert.strictEqual(formatNumber(999), '999', '#191: formatNumber(999) = "999"');
+    });
+
+    it('#191: formatNumber 소수', () => {
+        assert.strictEqual(formatNumber(3.14), '3.14', '#191: formatNumber(3.14) = "3.14"');
+        assert.strictEqual(formatNumber(0.5), '0.50', '#191: formatNumber(0.5) = "0.50"');
+        assert.strictEqual(formatNumber(99.999), '100.00', '#191: formatNumber(99.999) 반올림');
+    });
+
+    it('#191: formatNumber 큰 수 (1000 이상)', () => {
+        const result1000 = formatNumber(1000);
+        assert.ok(typeof result1000 === 'string', '#191: formatNumber(1000)은 문자열');
+        assert.ok(result1000.length >= 4, '#191: formatNumber(1000) 길이 >= 4');
+        const result999999 = formatNumber(999999);
+        assert.ok(typeof result999999 === 'string', '#191: formatNumber(999999)은 문자열');
+    });
+
+    it('#191: formatNumber NaN', () => {
+        assert.strictEqual(formatNumber(NaN), '-', '#191: formatNumber(NaN) = "-"');
+    });
+
+    it('#191: formatNumber Infinity', () => {
+        assert.strictEqual(formatNumber(Infinity), '-', '#191: formatNumber(Infinity) = "-"');
+        assert.strictEqual(formatNumber(-Infinity), '-', '#191: formatNumber(-Infinity) = "-"');
+    });
+
+    it('#191: getColorFromArray 정상 인덱스', () => {
+        const colors = ['#ff0000', '#00ff00', '#0000ff'];
+        assert.strictEqual(getColorFromArray(colors, 1, '#fff'), '#ff0000', '#191: level 1 → colors[0]');
+        assert.strictEqual(getColorFromArray(colors, 2, '#fff'), '#00ff00', '#191: level 2 → colors[1]');
+        assert.strictEqual(getColorFromArray(colors, 3, '#fff'), '#0000ff', '#191: level 3 → colors[2]');
+    });
+
+    it('#191: getColorFromArray 범위 초과 darken 폴백', () => {
+        const colors = ['#ff0000', '#00ff00'];
+        const result = getColorFromArray(colors, 4, '#fff');
+        assert.ok(typeof result === 'string', '#191: 범위 초과 시 문자열 반환');
+        assert.ok(result.startsWith('#'), '#191: 범위 초과 시 hex 색상 반환');
+        assert.ok(result !== '#00ff00', '#191: 범위 초과 시 마지막 색상과 다름 (darken 적용)');
+    });
+
+    it('#191: getColorFromArray 빈 배열', () => {
+        assert.strictEqual(getColorFromArray([], 1, '#fff'), '#fff', '#191: 빈 배열 시 fallback 반환');
+        assert.strictEqual(getColorFromArray(null, 1, '#abc'), '#abc', '#191: null 시 fallback 반환');
+        assert.strictEqual(getColorFromArray(undefined, 1, '#def'), '#def', '#191: undefined 시 fallback 반환');
+    });
+
+    it('#191: getTowerColor 타워 정의 기반 색상 반환', () => {
+        const basicDef = getTowerDefinition('basic');
+        const color1 = getTowerColor(basicDef, 1);
+        assert.ok(typeof color1 === 'string', '#191: getTowerColor 반환값은 문자열');
+        assert.ok(color1.startsWith('#'), '#191: getTowerColor 반환값은 hex 색상');
+        assert.strictEqual(color1, basicDef.levelColors[0], '#191: level 1은 levelColors[0]');
+        const color2 = getTowerColor(basicDef, 2);
+        assert.strictEqual(color2, basicDef.levelColors[1], '#191: level 2은 levelColors[1]');
+    });
+
+    it('#191: getProjectileColor 타워 정의 기반 색상 반환', () => {
+        const basicDef = getTowerDefinition('basic');
+        const color1 = getProjectileColor(basicDef, 1);
+        assert.ok(typeof color1 === 'string', '#191: getProjectileColor 반환값은 문자열');
+        assert.strictEqual(color1, basicDef.projectileColors[0], '#191: level 1은 projectileColors[0]');
+    });
+
+    it('#191: getTowerColor/getProjectileColor 높은 레벨 darken 폴백', () => {
+        const basicDef = getTowerDefinition('basic');
+        const highColor = getTowerColor(basicDef, 99);
+        assert.ok(typeof highColor === 'string', '#191: 높은 레벨 getTowerColor 문자열 반환');
+        assert.ok(highColor.startsWith('#'), '#191: 높은 레벨 getTowerColor hex 반환');
+        const highProjColor = getProjectileColor(basicDef, 99);
+        assert.ok(typeof highProjColor === 'string', '#191: 높은 레벨 getProjectileColor 문자열 반환');
+    });
+
+    it('#191: recalcTowerStats range 재계산', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        const def = getTowerDefinition('basic');
+        const origRange = tower.range;
+        tower.level = 5;
+        recalcTowerStats(tower);
+        const expectedRange = def.range + (def.rangeGrowth || 0) * (5 - 1);
+        assert.strictEqual(tower.range, expectedRange, '#191: recalcTowerStats range 재계산');
+        assert.ok(tower.range > origRange, '#191: 레벨 업 시 range 증가');
+    });
+
+    it('#191: recalcTowerStats fireDelay 재계산', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        const def = getTowerDefinition('basic');
+        tower.level = 5;
+        recalcTowerStats(tower);
+        const expectedFireDelay = Math.max(def.fireDelay + (def.fireDelayGrowth || 0) * (5 - 1), 0.05);
+        assert.strictEqual(tower.fireDelay, expectedFireDelay, '#191: recalcTowerStats fireDelay 재계산');
+    });
+
+    it('#191: recalcTowerStats damage 재계산', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        tower.level = 3;
+        recalcTowerStats(tower);
+        const def = getTowerDefinition('basic');
+        const expectedDmg = calculateTowerDamage(def, 3);
+        assert.strictEqual(tower.damage, expectedDmg, '#191: recalcTowerStats damage = calculateTowerDamage(def, 3)');
+    });
+
+    it('#191: recalcTowerStats upgradeCost 재계산', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        tower.level = 2;
+        recalcTowerStats(tower);
+        const def = getTowerDefinition('basic');
+        const expectedCost = calculateUpgradeCost(def, 2);
+        assert.strictEqual(tower.upgradeCost, expectedCost, '#191: recalcTowerStats upgradeCost 재계산');
+    });
+
+    it('#191: recalcTowerStats 최대 레벨 시 upgradeCost null', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        tower.level = TOWER_MAX_LEVEL;
+        recalcTowerStats(tower);
+        assert.strictEqual(tower.upgradeCost, null, '#191: 최대 레벨 시 upgradeCost는 null');
+    });
+
+    it('#191: recalcTowerStats cached 색상 업데이트', () => {
+        const tower = createTowerData(1, 1, 'basic');
+        tower.level = 3;
+        recalcTowerStats(tower);
+        const def = getTowerDefinition('basic');
+        assert.strictEqual(tower.cachedTowerColor, getTowerColor(def, 3), '#191: cachedTowerColor 업데이트');
+        assert.strictEqual(tower.cachedProjectileColor, getProjectileColor(def, 3), '#191: cachedProjectileColor 업데이트');
+        assert.strictEqual(tower.cachedTrailColor, getProjectileColor(def, 2), '#191: cachedTrailColor는 이전 레벨 색상');
+    });
 });

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -16,6 +16,7 @@ describe('Unit tests', () => {
     let getAdjustedPickRadius, getGameLoopHalted, towerPositionSet;
     let getRenderDirty, initKbCursor, moveKbCursor, activateKbCursor;
     let getKbCursor, getKbCursorActive, ENEMY_TYPE_MAP;
+    // #182: renderer globals are loaded via vm.runInThisContext into global scope
     const mockStyle = { body: '#fff', core: '#fff', outline: '#000', halo: 'rgba(255,255,255,0.5)' };
 
     before(() => {
@@ -1504,5 +1505,257 @@ describe('Unit tests', () => {
         const src = fs.readFileSync(path.join(__dirname, '..', 'renderer.js'), 'utf-8');
         assert.ok(src.includes('prefersReducedMotion ? 0.5'), '#192: renderer.js에 prefersReducedMotion 분기 존재');
         assert.ok(src.includes('pulseSeed'), '#192: renderer.js에 pulseSeed 사용');
+    });
+
+    // ── #182: 렌더러 함수 크래시 방지 테스트 ──
+
+    it('#182: drawEnemies 빈 배열에서 에러 없이 실행', () => {
+        enemies.length = 0;
+        let threw = false;
+        try {
+            drawEnemies();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawEnemies 빈 배열 시 크래시 없음');
+    });
+
+    it('#182: drawEnemies 최소 객체로 에러 없이 실행', () => {
+        enemies.length = 0;
+        enemies.push({
+            x: 100,
+            y: 100,
+            hp: 50,
+            maxHp: 50,
+            heading: 0,
+            pulseSeed: 0,
+            enemyType: mockStyle
+        });
+        let threw = false;
+        try {
+            drawEnemies();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawEnemies 최소 객체 시 크래시 없음');
+        enemies.length = 0;
+    });
+
+    it('#182: drawProjectiles 빈 배열에서 에러 없이 실행', () => {
+        projectiles.length = 0;
+        let threw = false;
+        try {
+            drawProjectiles();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawProjectiles 빈 배열 시 크래시 없음');
+    });
+
+    it('#182: drawProjectiles 최소 객체로 에러 없이 실행', () => {
+        projectiles.length = 0;
+        projectiles.push({
+            x: 100,
+            y: 100,
+            vx: 1,
+            vy: 0,
+            speed: 500,
+            damage: 10,
+            life: 1,
+            initialLife: 1,
+            delay: 0,
+            radius: 4,
+            color: '#fff',
+            shape: 'circle',
+            trailLength: 0
+        });
+        let threw = false;
+        try {
+            drawProjectiles();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawProjectiles 최소 객체 시 크래시 없음');
+        projectiles.length = 0;
+    });
+
+    it('#182: drawImpactEffects 빈 배열에서 에러 없이 실행', () => {
+        impactEffects.length = 0;
+        let threw = false;
+        try {
+            drawImpactEffects();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawImpactEffects 빈 배열 시 크래시 없음');
+    });
+
+    it('#182: drawImpactEffects 최소 객체로 에러 없이 실행', () => {
+        impactEffects.length = 0;
+        impactEffects.push({
+            x: 100,
+            y: 100,
+            radius: 20,
+            life: 0.5,
+            initialLife: 1,
+            color: '#ff0000',
+            halo: '#ff6600',
+            pulse: false
+        });
+        let threw = false;
+        try {
+            drawImpactEffects();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawImpactEffects 최소 객체 시 크래시 없음');
+        impactEffects.length = 0;
+    });
+
+    it('#182: drawMuzzleFlashes 빈 배열에서 에러 없이 실행', () => {
+        muzzleFlashes.length = 0;
+        let threw = false;
+        try {
+            drawMuzzleFlashes();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawMuzzleFlashes 빈 배열 시 크래시 없음');
+    });
+
+    it('#182: drawMuzzleFlashes 최소 객체로 에러 없이 실행', () => {
+        muzzleFlashes.length = 0;
+        muzzleFlashes.push({
+            x: 100,
+            y: 100,
+            radius: 8,
+            life: 0.3,
+            initialLife: 0.3,
+            color: '#fde7a2',
+            angle: 0
+        });
+        let threw = false;
+        try {
+            drawMuzzleFlashes();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawMuzzleFlashes 최소 객체 시 크래시 없음');
+        muzzleFlashes.length = 0;
+    });
+
+    it('#182: drawLaserBeams 빈 towers에서 에러 없이 실행', () => {
+        towers.length = 0;
+        let threw = false;
+        try {
+            drawLaserBeams();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawLaserBeams 빈 towers 시 크래시 없음');
+    });
+
+    it('#182: drawLaserBeams activeBeam이 있는 타워로 에러 없이 실행', () => {
+        towers.length = 0;
+        towers.push({
+            x: 3, y: 3, worldX: 100, worldY: 100,
+            activeBeam: {
+                x1: 100, y1: 100, x2: 200, y2: 200,
+                alpha: 0.8, color: '#00ff00', glow: '#66ff66', width: 6
+            }
+        });
+        let threw = false;
+        try {
+            drawLaserBeams();
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawLaserBeams activeBeam 시 크래시 없음');
+        towers.length = 0;
+    });
+
+    it('#182: drawProjectileTrail 에러 없이 실행', () => {
+        const mockProjectile = {
+            x: 100, y: 100, vx: 1, vy: 0,
+            speed: 500, trailLength: 30,
+            color: '#fff', trailColor: '#aaa', radius: 4
+        };
+        let threw = false;
+        try {
+            drawProjectileTrail(mockProjectile);
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawProjectileTrail 에러 없이 실행');
+    });
+
+    it('#182: drawProjectileTrail trailLength=0이면 조기 반환', () => {
+        const noTrail = { x: 50, y: 50, vx: 1, vy: 0, speed: 100, trailLength: 0 };
+        let threw = false;
+        try {
+            drawProjectileTrail(noTrail);
+        } catch (e) {
+            threw = true;
+        }
+        assert.strictEqual(threw, false, '#182: drawProjectileTrail trailLength=0 시 크래시 없음');
+    });
+
+    it('#182: render 에러 없이 실행', () => {
+        enemies.length = 0;
+        towers.length = 0;
+        projectiles.length = 0;
+        impactEffects.length = 0;
+        muzzleFlashes.length = 0;
+        // 이전 테스트에서 남은 상태 정리
+        kbCursorActive = false;
+        gameState.hoverTile = null;
+        gameState.paused = false;
+        gameState.gameLoopHalted = false;
+        buildStaticLayer();
+        let renderError = null;
+        try {
+            render();
+        } catch (e) {
+            renderError = e;
+        }
+        assert.strictEqual(renderError, null, '#182: render 빈 상태에서 크래시 없음');
+    });
+
+    it('#182: render 적·타워·투사체 조합으로 에러 없이 실행', () => {
+        enemies.length = 0;
+        towers.length = 0;
+        towerPositionSet.clear();
+        projectiles.length = 0;
+        impactEffects.length = 0;
+        muzzleFlashes.length = 0;
+        kbCursorActive = false;
+        gameState.hoverTile = null;
+        gameState.paused = false;
+        gameState.gameLoopHalted = false;
+        buildStaticLayer();
+        enemies.push({
+            x: 100, y: 100, hp: 50, maxHp: 50,
+            heading: 0, pulseSeed: 0, enemyType: mockStyle,
+            speed: 49, waypoint: 0, reward: 10, waveIndex: 1
+        });
+        const t = createTowerData(2, 2, 'basic');
+        towers.push(t);
+        towerPositionSet.add('2,2');
+        projectiles.push({
+            x: 80, y: 80, vx: 1, vy: 0, speed: 500,
+            damage: 10, life: 1, initialLife: 1, delay: 0,
+            radius: 4, color: '#fff', shape: 'circle', trailLength: 0
+        });
+        let renderError = null;
+        try {
+            render();
+        } catch (e) {
+            renderError = e;
+        }
+        assert.strictEqual(renderError, null, '#182: render 복합 상태에서 크래시 없음');
+        enemies.length = 0;
+        towers.length = 0;
+        towerPositionSet.clear();
+        projectiles.length = 0;
     });
 });


### PR DESCRIPTION
## Summary
- **#182**: 렌더러 함수(drawEnemies, drawProjectiles, drawImpactEffects, drawMuzzleFlashes, drawLaserBeams, drawProjectileTrail, render) 크래시 방지 테스트 추가
- **#190**: ESLint complexity/max-depth/max-lines-per-function warn 규칙 추가
- **#191**: utils.js 순수 함수(formatNumber, getColorFromArray, getTowerColor, getProjectileColor, recalcTowerStats) 테스트 추가
- **#193**: gameGlobals 자동 검증 스크립트(scripts/check-globals.mjs) 생성 + package.json 등록
- **#180**: CI에서 test:coverage 사용 + lint에 --max-warnings 0 추가

## Test plan
- [x] npm test 통과 (128 tests, 0 failures)
- [ ] CI 파이프라인에서 test:coverage 정상 실행 확인
- [ ] `npm run check-globals` 실행하여 누락/과잉 확인
- [ ] ESLint 경고 0 달성 후 lint 게이트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)